### PR TITLE
Social↔RPG integration: instant character, progression, character card, cross-platform sync

### DIFF
--- a/app/components/CharacterCard.tsx
+++ b/app/components/CharacterCard.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+type Card = {
+  gamertag: string | null;
+  class: string | null;
+  level: number;
+  xp: number;
+  hp: number; atk: number; def: number; mp: number; spd: number;
+  wins: number; losses: number; kills: number; deaths: number;
+};
+
+const CLASS_LABEL: Record<string, string> = {
+  phoenix: "Phoenix", dphoenix: "Dark Phoenix", dragon: "Dragon", ddragon: "Dark Dragon", kies: "Kies",
+};
+
+/** Public RPG character card for a user. Pass a userId; it fetches /api/users/:id/character-card. */
+export default function CharacterCard({ userId }: { userId?: string }) {
+  const [card, setCard] = useState<Card | null>(null);
+  const [state, setState] = useState<"loading" | "ok" | "none">("loading");
+
+  useEffect(() => {
+    if (!userId) return;
+    let active = true;
+    fetch(`/api/users/${userId}/character-card`)
+      .then((r) => (r.ok ? (r.json() as Promise<{ data: Card }>) : Promise.reject(new Error("no card"))))
+      .then((d) => { if (active) { setCard(d.data); setState("ok"); } })
+      .catch(() => active && setState("none"));
+    return () => { active = false; };
+  }, [userId]);
+
+  if (state === "loading") return <div className="rounded-2xl bg-white shadow p-5 animate-pulse h-40" />;
+  if (state === "none" || !card) return null;
+
+  const stat = (label: string, value: number) => (
+    <div className="flex flex-col items-center">
+      <span className="text-xs uppercase tracking-wide text-social-green-700/70">{label}</span>
+      <span className="font-bold text-social-green-900">{value.toLocaleString()}</span>
+    </div>
+  );
+
+  return (
+    <div className="rounded-2xl bg-gradient-to-br from-social-green-600 to-social-green-700 text-white shadow-lg p-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-wide opacity-80">RPG Character</div>
+          <div className="text-2xl font-extrabold leading-tight">{card.gamertag || "Unnamed"}</div>
+          <div className="opacity-90 text-sm">{card.class ? CLASS_LABEL[card.class] ?? card.class : "—"}</div>
+        </div>
+        <div className="text-right">
+          <div className="text-4xl font-black">Lv {card.level}</div>
+          <div className="text-xs opacity-80">{card.wins}W · {card.losses}L · {card.kills}K</div>
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-5 gap-2 rounded-xl bg-white/90 p-3">
+        {stat("HP", card.hp)}{stat("ATK", card.atk)}{stat("DEF", card.def)}{stat("MP", card.mp)}{stat("SPD", card.spd)}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/profile.me.tsx
+++ b/app/routes/profile.me.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { apiClient } from "../lib/api";
 import { useAuth } from "../lib/AuthContext";
+import CharacterCard from "../components/CharacterCard";
 
 type ProfileData = {
   username: string;
@@ -224,6 +225,9 @@ export default function MyProfilePage() {
 
         {/* Profile Info Overlay */}
         <div className="max-w-4xl mx-auto px-4">
+          <div className="pt-6">
+            <CharacterCard userId={user?.id} />
+          </div>
           <div className="relative -mt-20 flex flex-col md:flex-row items-center md:items-end gap-4">
             {/* Profile Picture with Upload */}
             <div className="relative group">

--- a/migrations/0009_social_sync.sql
+++ b/migrations/0009_social_sync.sql
@@ -1,0 +1,35 @@
+-- Cross-platform sync: link external social accounts and import their content into fullstack.
+
+CREATE TABLE IF NOT EXISTS social_connections (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    user_id TEXT NOT NULL,
+    provider TEXT NOT NULL,            -- mastodon | rss | bluesky | twitter | facebook | instagram | custom
+    handle TEXT,                       -- @user@instance, feed URL, profile URL, etc.
+    external_account_id TEXT,
+    access_token TEXT,                 -- optional; set via secret-backed flows, not required for public sources
+    status TEXT NOT NULL DEFAULT 'active', -- active | error | revoked
+    last_synced_at TIMESTAMP,
+    last_error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE (user_id, provider, handle)
+);
+CREATE INDEX IF NOT EXISTS idx_social_connections_user ON social_connections(user_id);
+
+CREATE TABLE IF NOT EXISTS imported_posts (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    user_id TEXT NOT NULL,
+    connection_id TEXT,
+    provider TEXT NOT NULL,
+    external_id TEXT NOT NULL,         -- id of the post on the source platform
+    author_handle TEXT,
+    body TEXT,
+    url TEXT,
+    posted_at TIMESTAMP,
+    raw_json TEXT,
+    imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (connection_id) REFERENCES social_connections(id) ON DELETE CASCADE,
+    UNIQUE (provider, external_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_imported_posts_user ON imported_posts(user_id, posted_at);

--- a/workers/src/api/auth.ts
+++ b/workers/src/api/auth.ts
@@ -8,8 +8,32 @@ import { magicLinkRequestSchema, magicLinkVerifySchema } from '../shared/schemas
 import { passwordResetRequestSchema, passwordResetSchema } from '../shared/schemas/password-reset';
 import { hashPassword, verifyPassword } from '../lib/auth';
 import { createSession } from '../lib/session';
+import { rollInitialCharacter, sanitizeGamertag } from '../core/classes';
 
 const auth = new Hono<{ Bindings: Bindings }>();
+
+// Build the INSERT for a brand-new, immediately-playable character (gamertag + class + base stats).
+async function buildInitialCharacter(db: D1Database, characterId: string, userId: string, seedUsername: string, founder: boolean) {
+  const gamertag = await generateUniqueGamertag(db, sanitizeGamertag(seedUsername));
+  const c = rollInitialCharacter({ seed: userId, autoMax: founder });
+  return db.prepare(
+    `INSERT INTO characters (id, user_id, slot_number, gamertag, class, level, xp, hp, atk, def, mp, spd, unspent_stat_points, first_game_access_completed)
+     VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)`
+  ).bind(characterId, userId, gamertag, c.cls, c.level, c.xp, c.hp, c.atk, c.def, c.mp, c.spd, c.unspentStatPoints);
+}
+
+async function generateUniqueGamertag(db: D1Database, base: string): Promise<string> {
+  let candidate = base || 'player';
+  let suffix = 0;
+  while (suffix < 10000) {
+    const exists = await db.prepare('SELECT 1 FROM characters WHERE gamertag = ?').bind(candidate).first();
+    if (!exists) return candidate.slice(0, 20);
+    suffix += 1;
+    candidate = `${base}${suffix}`.slice(0, 20);
+  }
+  return `${base.slice(0, 8)}_${Date.now()}`.slice(0, 20);
+}
+
 
 auth.post('/register', zValidator('json', registerSchema), async (c) => {
   const { email, username, password } = c.req.valid('json');
@@ -32,13 +56,12 @@ auth.post('/register', zValidator('json', registerSchema), async (c) => {
     const characterId = crypto.randomUUID();
 
     // Use a transaction to ensure all or nothing
+    const characterStmt = await buildInitialCharacter(db, characterId, userId, username, SPECIAL_USERNAMES.includes(username.toLowerCase()));
     const batch = [
       db.prepare(
         'INSERT INTO users (id, email, username, password_hash) VALUES (?, ?, ?, ?)'
       ).bind(userId, email, username, passwordHash),
-      db.prepare(
-        'INSERT INTO characters (id, user_id, first_game_access_completed) VALUES (?, ?, ?)'
-      ).bind(characterId, userId, false),
+      characterStmt,
       db.prepare(
         'INSERT INTO trophies (character_id) VALUES (?)'
       ).bind(characterId),
@@ -205,6 +228,7 @@ async function ensureUserFromGoogle(db: D1Database, profile: GoogleTokenPayload)
   const baseUsername = (profile.name || profile.given_name || 'g_user').toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 12) || 'guser';
   const username = await generateUniqueUsername(db, baseUsername);
 
+  const characterStmt = await buildInitialCharacter(db, characterId, userId, username, SPECIAL_USERNAMES.includes(username.toLowerCase()));
   const batch = [
     db.prepare(`INSERT INTO users (id, email, username, email_verified, avatar_url)
                 VALUES (?, ?, ?, ?, ?)`)
@@ -212,8 +236,7 @@ async function ensureUserFromGoogle(db: D1Database, profile: GoogleTokenPayload)
     db.prepare(`INSERT INTO oauth_accounts (id, user_id, provider, provider_account_id, scope, raw_profile_json)
                 VALUES (?, ?, ?, ?, ?, ?)`)
       .bind(crypto.randomUUID(), userId, 'google', profile.sub, 'openid email profile', rawProfileJson),
-    db.prepare('INSERT INTO characters (id, user_id, first_game_access_completed) VALUES (?, ?, ?)')
-      .bind(characterId, userId, false),
+    characterStmt,
     db.prepare('INSERT INTO trophies (character_id) VALUES (?)')
       .bind(characterId),
   ];
@@ -440,11 +463,11 @@ auth.post('/magic-link/verify', zValidator('json', magicLinkVerifySchema), async
       const baseUsername = tokenRecord.email.split('@')[0].toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 12) || 'user';
       const username = await generateUniqueUsername(db, baseUsername);
 
-      const batch = [
+      const characterStmt = await buildInitialCharacter(db, characterId, userId, username, SPECIAL_USERNAMES.includes(username.toLowerCase()));
+    const batch = [
         db.prepare('INSERT INTO users (id, email, username, email_verified) VALUES (?, ?, ?, ?)')
           .bind(userId, tokenRecord.email, username, true),
-        db.prepare('INSERT INTO characters (id, user_id, first_game_access_completed) VALUES (?, ?, ?)')
-          .bind(characterId, userId, false),
+        characterStmt,
         db.prepare('INSERT INTO trophies (character_id) VALUES (?)')
           .bind(characterId),
       ];

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import type { Bindings } from '../bindings';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedUser } from './middleware/auth';
-import { firstAccessSchema } from '../shared/schemas/game';
+import { firstAccessSchema, customizeCharacterSchema } from '../shared/schemas/game';
 import { MAX_LEVEL, getTotalStatPointsForLevel, getAllLevelAchievementsUpTo, getXpForLevel } from '../core/leveling';
+import { BASE_STATS, CHARACTER_CLASSES } from '../core/classes';
 
 type App = {
   Bindings: Bindings;
@@ -56,13 +57,6 @@ const game = new Hono<App>();
 // All routes in this file are protected
 game.use('*', authMiddleware);
 
-const BASE_STATS = {
-    phoenix:      { hp: 10000, atk: 1000, def: 500, mp: 175, spd: 100 },
-    dphoenix:     { hp: 10000, atk: 1750, def: 375, mp: 150, spd: 150 },
-    dragon:       { hp: 10000, atk: 750,  def: 1100, mp: 100, spd: 175 },
-    ddragon:      { hp: 10000, atk: 1000, def: 1000, mp: 200, spd: 75  },
-    kies:         { hp: 15000, atk: 750,  def: 750,  mp: 225, spd: 150 },
-};
 
 // Helper to check if user is a special account
 async function getSpecialAccount(db: D1Database, userId: string): Promise<SpecialAccount | null> {
@@ -329,6 +323,47 @@ game.post('/first-access', zValidator('json', firstAccessSchema), async (c) => {
   } catch (e) {
     console.error("Game first-access error:", e);
     return c.json({ error: 'Failed to set up character.' }, 500);
+  }
+});
+
+
+// Customize a starter character (gamertag/class) while it is still fresh (level 1, no XP).
+// Lets players personalize the auto-created character without first-access being a hard gate.
+game.post('/character/customize', zValidator('json', customizeCharacterSchema), async (c) => {
+  const user = c.get('user');
+  const { gamertag, class: chosenClass } = c.req.valid('json');
+  const db = c.env.DB;
+  try {
+    const ch = await db
+      .prepare('SELECT id, level, xp, class FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')
+      .bind(user.id)
+      .first<{ id: string; level: number; xp: number; class: string }>();
+    if (!ch) return c.json({ error: 'Character not found.' }, 404);
+    if (ch.level !== 1 || ch.xp > 0) {
+      return c.json({ error: 'Character has already progressed and can no longer be re-rolled. Create a new character in another slot instead.' }, 409);
+    }
+
+    if (gamertag) {
+      const taken = await db.prepare('SELECT 1 FROM characters WHERE gamertag = ? AND id != ?').bind(gamertag, ch.id).first();
+      if (taken) return c.json({ error: 'Gamertag is already taken.' }, 409);
+    }
+
+    const newClass = chosenClass ?? (ch.class as keyof typeof BASE_STATS);
+    const stats = BASE_STATS[newClass];
+
+    await db
+      .prepare(`UPDATE characters SET
+                  gamertag = COALESCE(?, gamertag),
+                  class = ?, hp = ?, atk = ?, def = ?, mp = ?, spd = ?,
+                  updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?`)
+      .bind(gamertag ?? null, newClass, stats.hp, stats.atk, stats.def, stats.mp, stats.spd, ch.id)
+      .run();
+
+    return c.json({ message: 'Character updated.', data: { class: newClass } });
+  } catch (e) {
+    console.error('Customize error:', e);
+    return c.json({ error: 'Failed to customize character.' }, 500);
   }
 });
 

--- a/workers/src/api/index.ts
+++ b/workers/src/api/index.ts
@@ -73,4 +73,10 @@ api.route('/payments', new Hono<{ Bindings: Bindings }>().all('*', async (c) => 
   return routes.fetch(createStrippedRequest(c), c.env, c.executionCtx);
 }));
 
+// Cross-platform sync routes - lazy loaded
+api.route('/sync', new Hono<{ Bindings: Bindings }>().all('*', async (c) => {
+  const { default: routes } = await import('./sync');
+  return routes.fetch(createStrippedRequest(c), c.env, c.executionCtx);
+}));
+
 export default api;

--- a/workers/src/api/social.ts
+++ b/workers/src/api/social.ts
@@ -4,6 +4,7 @@ import type { Bindings } from '../bindings';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedUser } from './middleware/auth';
 import { createCommentSchema, createGroupSchema, createPostSchema, reactSchema } from '../shared/schemas/social';
+import { awardProgress, REWARDS } from '../core/progression';
 
 type App = {
   Bindings: Bindings;
@@ -65,7 +66,8 @@ social.post('/posts', zValidator('json', createPostSchema), async (c) => {
     .bind(id, user.id, body)
     .run();
 
-  return c.json({ data: { id, body } }, 201);
+  const reward = await awardProgress(db, user.id, REWARDS.post);
+  return c.json({ data: { id, body }, reward }, 201);
 });
 
 social.post('/posts/:id/comments', zValidator('json', createCommentSchema), async (c) => {
@@ -80,7 +82,8 @@ social.post('/posts/:id/comments', zValidator('json', createCommentSchema), asyn
     .bind(commentId, id, user.id, body)
     .run();
 
-  return c.json({ data: { id: commentId } }, 201);
+  const reward = await awardProgress(db, user.id, REWARDS.comment);
+  return c.json({ data: { id: commentId }, reward }, 201);
 });
 
 social.post('/posts/:id/react', zValidator('json', reactSchema), async (c) => {
@@ -100,6 +103,12 @@ social.post('/posts/:id/react', zValidator('json', reactSchema), async (c) => {
     .prepare('INSERT INTO reactions (id, post_id, user_id, type) VALUES (?, ?, ?, ?)')
     .bind(reactionId, id, user.id, type)
     .run();
+
+  // Reward the post author for the engagement (not the reactor), if it isn't a self-reaction.
+  const post = await db.prepare('SELECT author_id FROM posts WHERE id = ?').bind(id).first<{ author_id: string }>();
+  if (post && post.author_id !== user.id) {
+    c.executionCtx.waitUntil(awardProgress(db, post.author_id, REWARDS.reactionReceived).then(() => {}));
+  }
 
   return c.json({ message: 'Reacted' }, 201);
 });

--- a/workers/src/api/sync.ts
+++ b/workers/src/api/sync.ts
@@ -1,0 +1,121 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import type { Bindings } from '../bindings';
+import { authMiddleware } from './middleware/auth';
+import type { AuthenticatedUser } from './middleware/auth';
+import { getConnector, CONNECTORS, type NormalizedPost } from '../core/connectors';
+
+type App = { Bindings: Bindings; Variables: { user: AuthenticatedUser } };
+const sync = new Hono<App>();
+sync.use('*', authMiddleware);
+
+// List available providers and whether they work without OAuth/app review.
+sync.get('/providers', (c) =>
+  c.json({ data: Object.values(CONNECTORS).map((x) => ({ provider: x.provider, selfServe: x.selfServe })) })
+);
+
+// List the current user's connected accounts.
+sync.get('/connections', async (c) => {
+  const user = c.get('user');
+  const { results } = await c.env.DB
+    .prepare('SELECT id, provider, handle, status, last_synced_at, last_error, created_at FROM social_connections WHERE user_id = ? ORDER BY created_at DESC')
+    .bind(user.id).all();
+  return c.json({ data: results });
+});
+
+const addConnectionSchema = z.object({
+  provider: z.string().min(2),
+  handle: z.string().min(1),
+});
+
+sync.post('/connections', zValidator('json', addConnectionSchema), async (c) => {
+  const user = c.get('user');
+  const { provider, handle } = c.req.valid('json');
+  if (!getConnector(provider)) return c.json({ error: `Unknown provider "${provider}"` }, 400);
+  const id = crypto.randomUUID();
+  try {
+    await c.env.DB
+      .prepare('INSERT INTO social_connections (id, user_id, provider, handle) VALUES (?, ?, ?, ?)')
+      .bind(id, user.id, provider, handle).run();
+  } catch {
+    return c.json({ error: 'That account is already connected' }, 409);
+  }
+  return c.json({ data: { id, provider, handle } }, 201);
+});
+
+sync.delete('/connections/:id', async (c) => {
+  const user = c.get('user');
+  await c.env.DB.prepare('DELETE FROM social_connections WHERE id = ? AND user_id = ?')
+    .bind(c.req.param('id'), user.id).run();
+  return c.json({ ok: true });
+});
+
+async function storePosts(db: D1Database, userId: string, connectionId: string | null, provider: string, posts: NormalizedPost[]): Promise<number> {
+  let imported = 0;
+  for (const p of posts.slice(0, 100)) {
+    if (!p.externalId || !p.body) continue;
+    const res = await db
+      .prepare(`INSERT OR IGNORE INTO imported_posts (user_id, connection_id, provider, external_id, author_handle, body, url, posted_at, raw_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .bind(userId, connectionId, provider, p.externalId, p.authorHandle ?? null, p.body, p.url ?? null, p.postedAt ?? null, p.raw ? JSON.stringify(p.raw) : null)
+      .run();
+    imported += res.meta.changes ?? 0;
+  }
+  return imported;
+}
+
+// Pull latest content for one connection via its connector.
+sync.post('/connections/:id/sync', async (c) => {
+  const user = c.get('user');
+  const conn = await c.env.DB
+    .prepare('SELECT id, provider, handle, access_token FROM social_connections WHERE id = ? AND user_id = ?')
+    .bind(c.req.param('id'), user.id)
+    .first<{ id: string; provider: string; handle: string; access_token: string | null }>();
+  if (!conn) return c.json({ error: 'Connection not found' }, 404);
+
+  const connector = getConnector(conn.provider);
+  if (!connector) return c.json({ error: 'Unknown provider' }, 400);
+
+  try {
+    const posts = await connector.fetchPosts({ handle: conn.handle, accessToken: conn.access_token });
+    const imported = await storePosts(c.env.DB, user.id, conn.id, conn.provider, posts);
+    await c.env.DB.prepare('UPDATE social_connections SET last_synced_at = CURRENT_TIMESTAMP, status = ?, last_error = NULL WHERE id = ?')
+      .bind('active', conn.id).run();
+    return c.json({ data: { fetched: posts.length, imported } });
+  } catch (e: any) {
+    await c.env.DB.prepare('UPDATE social_connections SET status = ?, last_error = ? WHERE id = ?')
+      .bind('error', String(e?.message ?? e), conn.id).run();
+    return c.json({ error: String(e?.message ?? 'sync failed') }, 502);
+  }
+});
+
+// Generic push import — for platforms (or your own integrations) to sync data INTO fullstack.
+const importSchema = z.object({
+  provider: z.string().min(2),
+  posts: z.array(z.object({
+    externalId: z.string(),
+    authorHandle: z.string().optional(),
+    body: z.string(),
+    url: z.string().optional(),
+    postedAt: z.string().optional(),
+  })).max(100),
+});
+
+sync.post('/import', zValidator('json', importSchema), async (c) => {
+  const user = c.get('user');
+  const { provider, posts } = c.req.valid('json');
+  const imported = await storePosts(c.env.DB, user.id, null, provider, posts);
+  return c.json({ data: { received: posts.length, imported } });
+});
+
+// Unified imported feed for the user.
+sync.get('/feed', async (c) => {
+  const user = c.get('user');
+  const { results } = await c.env.DB
+    .prepare('SELECT provider, author_handle, body, url, posted_at FROM imported_posts WHERE user_id = ? ORDER BY COALESCE(posted_at, imported_at) DESC LIMIT 50')
+    .bind(user.id).all();
+  return c.json({ data: results });
+});
+
+export default sync;

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -16,6 +16,25 @@ type App = {
 
 const users = new Hono<App>();
 
+// Fetch a user's showcase character card (highest-level set-up character).
+async function getCharacterCard(db: D1Database, userId: string) {
+  return db
+    .prepare(
+      `SELECT c.gamertag, c.class, c.level, c.xp, c.slot_number,
+              c.hp, c.atk, c.def, c.mp, c.spd,
+              COALESCE(t.wins,0) AS wins, COALESCE(t.losses,0) AS losses,
+              COALESCE(t.kills,0) AS kills, COALESCE(t.deaths,0) AS deaths
+       FROM characters c
+       LEFT JOIN trophies t ON t.character_id = c.id
+       WHERE c.user_id = ? AND c.first_game_access_completed = TRUE
+       ORDER BY c.level DESC, c.slot_number ASC
+       LIMIT 1`
+    )
+    .bind(userId)
+    .first();
+}
+
+
 // GET /api/users/me - Get the current authenticated user's profile and main character id
 users.get('/me', authMiddleware, async (c) => {
   const user = c.get('user');
@@ -132,10 +151,17 @@ users.get('/:id/profile', async (c) => {
     return c.json({ error: 'User not found' }, 404);
   }
 
-  // We can also fetch and join social stats like post count, friend count etc. here
-  // For now, just the basic profile is fine.
+  const character = await getCharacterCard(db, id);
+  return c.json({ data: { ...profile, character } });
+});
 
-  return c.json({ data: profile });
+// GET /api/users/:id/character-card - Public RPG character card for a user
+users.get('/:id/character-card', async (c) => {
+  const { id } = c.req.param();
+  const db = c.env.DB;
+  const character = await getCharacterCard(db, id);
+  if (!character) return c.json({ error: 'No character found' }, 404);
+  return c.json({ data: character });
 });
 
 export default users;

--- a/workers/src/core/classes.ts
+++ b/workers/src/core/classes.ts
@@ -1,0 +1,46 @@
+/**
+ * Character classes and base stats — shared by the game API and the signup flow
+ * so a playable character can be created the moment a user registers.
+ */
+import { MAX_LEVEL, getTotalStatPointsForLevel } from './leveling';
+
+export const CHARACTER_CLASSES = ['phoenix', 'dphoenix', 'dragon', 'ddragon', 'kies'] as const;
+export type CharacterClass = (typeof CHARACTER_CLASSES)[number];
+
+export interface BaseStats { hp: number; atk: number; def: number; mp: number; spd: number; }
+
+export const BASE_STATS: Record<CharacterClass, BaseStats> = {
+  phoenix:  { hp: 10000, atk: 1000, def: 500,  mp: 175, spd: 100 },
+  dphoenix: { hp: 10000, atk: 1750, def: 375,  mp: 150, spd: 150 },
+  dragon:   { hp: 10000, atk: 750,  def: 1100, mp: 100, spd: 175 },
+  ddragon:  { hp: 10000, atk: 1000, def: 1000, mp: 200, spd: 75  },
+  kies:     { hp: 15000, atk: 750,  def: 750,  mp: 225, spd: 150 },
+};
+
+/** Deterministically pick a starter class from a seed (stable per user, gives variety across signups). */
+export function defaultClassFor(seed: string): CharacterClass {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
+  return CHARACTER_CLASSES[h % CHARACTER_CLASSES.length];
+}
+
+export interface InitialCharacter extends BaseStats {
+  cls: CharacterClass; level: number; xp: number; unspentStatPoints: number;
+}
+
+/** Compute the starting field values for a brand-new character. */
+export function rollInitialCharacter(opts: { seed: string; cls?: CharacterClass; autoMax?: boolean }): InitialCharacter {
+  const cls = opts.cls ?? defaultClassFor(opts.seed);
+  const s = BASE_STATS[cls];
+  const level = opts.autoMax ? MAX_LEVEL : 1;
+  const xp = opts.autoMax ? 999_999_999 : 0;
+  const unspentStatPoints = opts.autoMax ? getTotalStatPointsForLevel(MAX_LEVEL) : 0;
+  return { cls, level, xp, unspentStatPoints, ...s };
+}
+
+/** Sanitize a social username into a valid gamertag candidate (3–20 chars, [A-Za-z0-9_.-]). */
+export function sanitizeGamertag(raw: string): string {
+  let t = (raw || '').replace(/[^a-zA-Z0-9_.-]/g, '').slice(0, 20);
+  while (t.length < 3) t += '0';
+  return t;
+}

--- a/workers/src/core/connectors.ts
+++ b/workers/src/core/connectors.ts
@@ -1,0 +1,108 @@
+/**
+ * Cross-platform connectors. A connector knows how to pull a normalized list of posts
+ * from an external source so they can be imported into fullstack's unified feed.
+ *
+ * Feasible-today connectors (no app review needed):
+ *   - mastodon: public statuses via the instance API
+ *   - rss:      any RSS/Atom feed (Substack, YouTube, blogs, many platforms expose one)
+ * Proprietary networks (twitter/x, facebook, instagram) require platform OAuth + app review,
+ * so they are represented as stubs plus the generic `push` import path (POST /api/sync/import).
+ */
+
+export interface NormalizedPost {
+  externalId: string;
+  authorHandle?: string;
+  body: string;
+  url?: string;
+  postedAt?: string; // ISO
+  raw?: unknown;
+}
+
+export interface ConnectorContext { handle: string; accessToken?: string | null; }
+export interface SocialConnector {
+  provider: string;
+  /** True if this connector can run without per-user OAuth/app review. */
+  selfServe: boolean;
+  fetchPosts(ctx: ConnectorContext): Promise<NormalizedPost[]>;
+}
+
+const stripHtml = (s: string) => s.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").trim();
+
+// ---- Mastodon (public) ----
+const mastodon: SocialConnector = {
+  provider: "mastodon",
+  selfServe: true,
+  async fetchPosts({ handle }) {
+    // handle: @user@instance  OR  user@instance
+    const m = handle.replace(/^@/, "").match(/^([^@]+)@(.+)$/);
+    if (!m) throw new Error("mastodon handle must look like user@instance.social");
+    const [, user, instance] = m;
+    const base = `https://${instance}`;
+    const lookup = await fetch(`${base}/api/v1/accounts/lookup?acct=${encodeURIComponent(user)}`, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!lookup.ok) throw new Error(`mastodon account lookup failed (${lookup.status})`);
+    const acct = (await lookup.json()) as { id: string };
+    const res = await fetch(`${base}/api/v1/accounts/${acct.id}/statuses?limit=20&exclude_replies=true`, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!res.ok) throw new Error(`mastodon statuses failed (${res.status})`);
+    const statuses = (await res.json()) as any[];
+    return statuses.map((s) => ({
+      externalId: String(s.id),
+      authorHandle: `@${user}@${instance}`,
+      body: stripHtml(s.content || ""),
+      url: s.url || s.uri,
+      postedAt: s.created_at,
+      raw: s,
+    }));
+  },
+};
+
+// ---- RSS / Atom (generic) ----
+const rss: SocialConnector = {
+  provider: "rss",
+  selfServe: true,
+  async fetchPosts({ handle }) {
+    if (!/^https?:\/\//.test(handle)) throw new Error("rss handle must be a feed URL");
+    const res = await fetch(handle, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!res.ok) throw new Error(`rss fetch failed (${res.status})`);
+    const xml = await res.text();
+    const items = xml.split(/<item[\s>]/).slice(1).concat(xml.split(/<entry[\s>]/).slice(1));
+    const pick = (block: string, tag: string) => {
+      const m = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"));
+      return m ? m[1].replace(/<!\\[CDATA\\[|\\]\\]>/g, "").trim() : "";
+    };
+    return items.slice(0, 20).map((block, i) => {
+      const link = pick(block, "link") || (block.match(/<link[^>]*href="([^"]+)"/i)?.[1] ?? "");
+      const guid = pick(block, "guid") || link || String(i);
+      return {
+        externalId: guid,
+        body: stripHtml(pick(block, "title")) + (pick(block, "description") ? " — " + stripHtml(pick(block, "description")).slice(0, 280) : ""),
+        url: link,
+        postedAt: pick(block, "pubDate") || pick(block, "updated") || undefined,
+        raw: undefined,
+      };
+    });
+  },
+};
+
+// ---- Proprietary stubs (require OAuth + platform app review) ----
+function oauthStub(provider: string): SocialConnector {
+  return {
+    provider,
+    selfServe: false,
+    async fetchPosts() {
+      throw new Error(`${provider} requires OAuth + platform app review. Use POST /api/sync/import to push normalized posts from your ${provider} integration instead.`);
+    },
+  };
+}
+
+export const CONNECTORS: Record<string, SocialConnector> = {
+  mastodon,
+  rss,
+  bluesky: oauthStub("bluesky"),
+  twitter: oauthStub("twitter"),
+  facebook: oauthStub("facebook"),
+  instagram: oauthStub("instagram"),
+};
+
+export function getConnector(provider: string): SocialConnector | null {
+  return CONNECTORS[provider] ?? null;
+}

--- a/workers/src/core/progression.ts
+++ b/workers/src/core/progression.ts
@@ -1,0 +1,56 @@
+/**
+ * Social → RPG progression bridge.
+ * Grants XP / currency to a user's primary character for social engagement,
+ * handling level-ups via the shared leveling rules.
+ */
+import { checkForLevelUp, MAX_LEVEL } from './leveling';
+
+export interface ProgressReward { xp?: number; currency?: number; }
+export interface ProgressResult { characterId: string; xp: number; level: number; leveledUp: boolean; pointsGained: number; currency: number; }
+
+export async function awardProgress(
+  db: D1Database,
+  userId: string,
+  reward: ProgressReward
+): Promise<ProgressResult | null> {
+  const ch = await db
+    .prepare('SELECT id, level, xp, unspent_stat_points, unbanked_currency FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')
+    .bind(userId)
+    .first<{ id: string; level: number; xp: number; unspent_stat_points: number; unbanked_currency: number }>();
+  if (!ch) return null;
+
+  const addXp = Math.max(0, reward.xp ?? 0);
+  const addCurrency = Math.max(0, reward.currency ?? 0);
+  const newXp = ch.xp + addXp;
+
+  let level = ch.level;
+  let pointsGained = 0;
+  if (level < MAX_LEVEL && addXp > 0) {
+    const lvl = checkForLevelUp(ch.level, newXp);
+    if (lvl) { level = lvl.newLevel; pointsGained = lvl.pointsGained; }
+  }
+
+  await db
+    .prepare(`UPDATE characters
+              SET xp = ?, level = ?, unspent_stat_points = unspent_stat_points + ?,
+                  unbanked_currency = unbanked_currency + ?, updated_at = CURRENT_TIMESTAMP
+              WHERE id = ?`)
+    .bind(newXp, level, pointsGained, addCurrency, ch.id)
+    .run();
+
+  return {
+    characterId: ch.id,
+    xp: newXp,
+    level,
+    leveledUp: level > ch.level,
+    pointsGained,
+    currency: (ch.unbanked_currency ?? 0) + addCurrency,
+  };
+}
+
+/** Reward amounts for each social action (tune freely). */
+export const REWARDS = {
+  post: { xp: 10, currency: 5 },
+  comment: { xp: 5, currency: 2 },
+  reactionReceived: { xp: 3, currency: 1 }, // to the post author when someone reacts
+} as const;

--- a/workers/src/shared/schemas/game.ts
+++ b/workers/src/shared/schemas/game.ts
@@ -23,6 +23,21 @@ export const allocatePointsSchema = z.object({
 
 
 export type FirstAccessInput = z.infer<typeof firstAccessSchema>;
+
+export const customizeCharacterSchema = z
+  .object({
+    gamertag: z
+      .string()
+      .min(3, { message: 'Gamertag must be at least 3 characters long' })
+      .max(20, { message: 'Gamertag must be no more than 20 characters long' })
+      .regex(/^[a-zA-Z0-9_.-]+$/, { message: 'Gamertag can only contain letters, numbers, underscores, dots, and hyphens' })
+      .optional(),
+    class: z.enum(['phoenix', 'dphoenix', 'dragon', 'ddragon', 'kies']).optional(),
+  })
+  .refine((d) => d.gamertag || d.class, { message: 'Provide a gamertag and/or a class to change' });
+
+export type CustomizeCharacterInput = z.infer<typeof customizeCharacterSchema>;
+
 export type AllocatePointsInput = z.infer<typeof allocatePointsSchema>;
 
 export const createBattleSchema = z.object({


### PR DESCRIPTION
Four-part build toward the integratable social hub + underlying RPG:

1. **Instant playable character at signup** — all 3 auth paths (password/Google/magic-link) now create a full character (unique gamertag, deterministic starter class, base stats); shared `core/classes.ts`; new `POST /game/character/customize` so first-access is optional, not a gate.
2. **Social actions drive RPG** — `core/progression.ts awardProgress()` grants XP+currency (with level-ups) for posting/commenting; receiving a reaction rewards the post author.
3. **Character card** — `getCharacterCard()` + `GET /api/users/:id/character-card`, enriched profile, reusable `CharacterCard.tsx` surfaced on the profile page.
4. **Cross-platform sync foundation** — `0009_social_sync.sql` (social_connections + imported_posts), `core/connectors.ts` (Mastodon + RSS self-serve pull connectors, OAuth stubs for X/FB/IG/Bluesky), `api/sync.ts` (connections CRUD, per-connection sync, generic `POST /import` push, unified `/feed`).

Typechecks clean (only pre-existing react-router generated-type stubs remain). Needs `wrangler d1 ... 0009` migration + browser QA before merge.