### PR TITLE
1/7 Shared character class module + optional customize endpoint

### DIFF
--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import type { Bindings } from '../bindings';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedUser } from './middleware/auth';
-import { firstAccessSchema } from '../shared/schemas/game';
+import { firstAccessSchema, customizeCharacterSchema } from '../shared/schemas/game';
 import { MAX_LEVEL, getTotalStatPointsForLevel, getAllLevelAchievementsUpTo, getXpForLevel } from '../core/leveling';
+import { BASE_STATS, CHARACTER_CLASSES } from '../core/classes';
 
 type App = {
   Bindings: Bindings;
@@ -56,13 +57,6 @@ const game = new Hono<App>();
 // All routes in this file are protected
 game.use('*', authMiddleware);
 
-const BASE_STATS = {
-    phoenix:      { hp: 10000, atk: 1000, def: 500, mp: 175, spd: 100 },
-    dphoenix:     { hp: 10000, atk: 1750, def: 375, mp: 150, spd: 150 },
-    dragon:       { hp: 10000, atk: 750,  def: 1100, mp: 100, spd: 175 },
-    ddragon:      { hp: 10000, atk: 1000, def: 1000, mp: 200, spd: 75  },
-    kies:         { hp: 15000, atk: 750,  def: 750,  mp: 225, spd: 150 },
-};
 
 // Helper to check if user is a special account
 async function getSpecialAccount(db: D1Database, userId: string): Promise<SpecialAccount | null> {
@@ -329,6 +323,47 @@ game.post('/first-access', zValidator('json', firstAccessSchema), async (c) => {
   } catch (e) {
     console.error("Game first-access error:", e);
     return c.json({ error: 'Failed to set up character.' }, 500);
+  }
+});
+
+
+// Customize a starter character (gamertag/class) while it is still fresh (level 1, no XP).
+// Lets players personalize the auto-created character without first-access being a hard gate.
+game.post('/character/customize', zValidator('json', customizeCharacterSchema), async (c) => {
+  const user = c.get('user');
+  const { gamertag, class: chosenClass } = c.req.valid('json');
+  const db = c.env.DB;
+  try {
+    const ch = await db
+      .prepare('SELECT id, level, xp, class FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')
+      .bind(user.id)
+      .first<{ id: string; level: number; xp: number; class: string }>();
+    if (!ch) return c.json({ error: 'Character not found.' }, 404);
+    if (ch.level !== 1 || ch.xp > 0) {
+      return c.json({ error: 'Character has already progressed and can no longer be re-rolled. Create a new character in another slot instead.' }, 409);
+    }
+
+    if (gamertag) {
+      const taken = await db.prepare('SELECT 1 FROM characters WHERE gamertag = ? AND id != ?').bind(gamertag, ch.id).first();
+      if (taken) return c.json({ error: 'Gamertag is already taken.' }, 409);
+    }
+
+    const newClass = chosenClass ?? (ch.class as keyof typeof BASE_STATS);
+    const stats = BASE_STATS[newClass];
+
+    await db
+      .prepare(`UPDATE characters SET
+                  gamertag = COALESCE(?, gamertag),
+                  class = ?, hp = ?, atk = ?, def = ?, mp = ?, spd = ?,
+                  updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?`)
+      .bind(gamertag ?? null, newClass, stats.hp, stats.atk, stats.def, stats.mp, stats.spd, ch.id)
+      .run();
+
+    return c.json({ message: 'Character updated.', data: { class: newClass } });
+  } catch (e) {
+    console.error('Customize error:', e);
+    return c.json({ error: 'Failed to customize character.' }, 500);
   }
 });
 

--- a/workers/src/core/classes.ts
+++ b/workers/src/core/classes.ts
@@ -1,0 +1,46 @@
+/**
+ * Character classes and base stats — shared by the game API and the signup flow
+ * so a playable character can be created the moment a user registers.
+ */
+import { MAX_LEVEL, getTotalStatPointsForLevel } from './leveling';
+
+export const CHARACTER_CLASSES = ['phoenix', 'dphoenix', 'dragon', 'ddragon', 'kies'] as const;
+export type CharacterClass = (typeof CHARACTER_CLASSES)[number];
+
+export interface BaseStats { hp: number; atk: number; def: number; mp: number; spd: number; }
+
+export const BASE_STATS: Record<CharacterClass, BaseStats> = {
+  phoenix:  { hp: 10000, atk: 1000, def: 500,  mp: 175, spd: 100 },
+  dphoenix: { hp: 10000, atk: 1750, def: 375,  mp: 150, spd: 150 },
+  dragon:   { hp: 10000, atk: 750,  def: 1100, mp: 100, spd: 175 },
+  ddragon:  { hp: 10000, atk: 1000, def: 1000, mp: 200, spd: 75  },
+  kies:     { hp: 15000, atk: 750,  def: 750,  mp: 225, spd: 150 },
+};
+
+/** Deterministically pick a starter class from a seed (stable per user, gives variety across signups). */
+export function defaultClassFor(seed: string): CharacterClass {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
+  return CHARACTER_CLASSES[h % CHARACTER_CLASSES.length];
+}
+
+export interface InitialCharacter extends BaseStats {
+  cls: CharacterClass; level: number; xp: number; unspentStatPoints: number;
+}
+
+/** Compute the starting field values for a brand-new character. */
+export function rollInitialCharacter(opts: { seed: string; cls?: CharacterClass; autoMax?: boolean }): InitialCharacter {
+  const cls = opts.cls ?? defaultClassFor(opts.seed);
+  const s = BASE_STATS[cls];
+  const level = opts.autoMax ? MAX_LEVEL : 1;
+  const xp = opts.autoMax ? 999_999_999 : 0;
+  const unspentStatPoints = opts.autoMax ? getTotalStatPointsForLevel(MAX_LEVEL) : 0;
+  return { cls, level, xp, unspentStatPoints, ...s };
+}
+
+/** Sanitize a social username into a valid gamertag candidate (3–20 chars, [A-Za-z0-9_.-]). */
+export function sanitizeGamertag(raw: string): string {
+  let t = (raw || '').replace(/[^a-zA-Z0-9_.-]/g, '').slice(0, 20);
+  while (t.length < 3) t += '0';
+  return t;
+}

--- a/workers/src/shared/schemas/game.ts
+++ b/workers/src/shared/schemas/game.ts
@@ -23,6 +23,21 @@ export const allocatePointsSchema = z.object({
 
 
 export type FirstAccessInput = z.infer<typeof firstAccessSchema>;
+
+export const customizeCharacterSchema = z
+  .object({
+    gamertag: z
+      .string()
+      .min(3, { message: 'Gamertag must be at least 3 characters long' })
+      .max(20, { message: 'Gamertag must be no more than 20 characters long' })
+      .regex(/^[a-zA-Z0-9_.-]+$/, { message: 'Gamertag can only contain letters, numbers, underscores, dots, and hyphens' })
+      .optional(),
+    class: z.enum(['phoenix', 'dphoenix', 'dragon', 'ddragon', 'kies']).optional(),
+  })
+  .refine((d) => d.gamertag || d.class, { message: 'Provide a gamertag and/or a class to change' });
+
+export type CustomizeCharacterInput = z.infer<typeof customizeCharacterSchema>;
+
 export type AllocatePointsInput = z.infer<typeof allocatePointsSchema>;
 
 export const createBattleSchema = z.object({


### PR DESCRIPTION
Part 1 of 7 — splits PR #7 into reviewable units.

Extracts BASE_STATS/CHARACTER_CLASSES into `workers/src/core/classes.ts` (shared by game + auth), refactors `game.ts` to use it, and adds `POST /game/character/customize` so first-access becomes an optional level-1 re-roll instead of a hard gate.

Files: core/classes.ts (new), api/game.ts, shared/schemas/game.ts.
Base: main. Merge order: this is #1 of the stack.