### PR TITLE
3/7 Social actions grant RPG progression

### DIFF
--- a/workers/src/api/social.ts
+++ b/workers/src/api/social.ts
@@ -4,6 +4,7 @@ import type { Bindings } from '../bindings';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedUser } from './middleware/auth';
 import { createCommentSchema, createGroupSchema, createPostSchema, reactSchema } from '../shared/schemas/social';
+import { awardProgress, REWARDS } from '../core/progression';
 
 type App = {
   Bindings: Bindings;
@@ -65,7 +66,8 @@ social.post('/posts', zValidator('json', createPostSchema), async (c) => {
     .bind(id, user.id, body)
     .run();
 
-  return c.json({ data: { id, body } }, 201);
+  const reward = await awardProgress(db, user.id, REWARDS.post);
+  return c.json({ data: { id, body }, reward }, 201);
 });
 
 social.post('/posts/:id/comments', zValidator('json', createCommentSchema), async (c) => {
@@ -80,7 +82,8 @@ social.post('/posts/:id/comments', zValidator('json', createCommentSchema), asyn
     .bind(commentId, id, user.id, body)
     .run();
 
-  return c.json({ data: { id: commentId } }, 201);
+  const reward = await awardProgress(db, user.id, REWARDS.comment);
+  return c.json({ data: { id: commentId }, reward }, 201);
 });
 
 social.post('/posts/:id/react', zValidator('json', reactSchema), async (c) => {
@@ -100,6 +103,12 @@ social.post('/posts/:id/react', zValidator('json', reactSchema), async (c) => {
     .prepare('INSERT INTO reactions (id, post_id, user_id, type) VALUES (?, ?, ?, ?)')
     .bind(reactionId, id, user.id, type)
     .run();
+
+  // Reward the post author for the engagement (not the reactor), if it isn't a self-reaction.
+  const post = await db.prepare('SELECT author_id FROM posts WHERE id = ?').bind(id).first<{ author_id: string }>();
+  if (post && post.author_id !== user.id) {
+    c.executionCtx.waitUntil(awardProgress(db, post.author_id, REWARDS.reactionReceived).then(() => {}));
+  }
 
   return c.json({ message: 'Reacted' }, 201);
 });

--- a/workers/src/core/progression.ts
+++ b/workers/src/core/progression.ts
@@ -1,0 +1,56 @@
+/**
+ * Social → RPG progression bridge.
+ * Grants XP / currency to a user's primary character for social engagement,
+ * handling level-ups via the shared leveling rules.
+ */
+import { checkForLevelUp, MAX_LEVEL } from './leveling';
+
+export interface ProgressReward { xp?: number; currency?: number; }
+export interface ProgressResult { characterId: string; xp: number; level: number; leveledUp: boolean; pointsGained: number; currency: number; }
+
+export async function awardProgress(
+  db: D1Database,
+  userId: string,
+  reward: ProgressReward
+): Promise<ProgressResult | null> {
+  const ch = await db
+    .prepare('SELECT id, level, xp, unspent_stat_points, unbanked_currency FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')
+    .bind(userId)
+    .first<{ id: string; level: number; xp: number; unspent_stat_points: number; unbanked_currency: number }>();
+  if (!ch) return null;
+
+  const addXp = Math.max(0, reward.xp ?? 0);
+  const addCurrency = Math.max(0, reward.currency ?? 0);
+  const newXp = ch.xp + addXp;
+
+  let level = ch.level;
+  let pointsGained = 0;
+  if (level < MAX_LEVEL && addXp > 0) {
+    const lvl = checkForLevelUp(ch.level, newXp);
+    if (lvl) { level = lvl.newLevel; pointsGained = lvl.pointsGained; }
+  }
+
+  await db
+    .prepare(`UPDATE characters
+              SET xp = ?, level = ?, unspent_stat_points = unspent_stat_points + ?,
+                  unbanked_currency = unbanked_currency + ?, updated_at = CURRENT_TIMESTAMP
+              WHERE id = ?`)
+    .bind(newXp, level, pointsGained, addCurrency, ch.id)
+    .run();
+
+  return {
+    characterId: ch.id,
+    xp: newXp,
+    level,
+    leveledUp: level > ch.level,
+    pointsGained,
+    currency: (ch.unbanked_currency ?? 0) + addCurrency,
+  };
+}
+
+/** Reward amounts for each social action (tune freely). */
+export const REWARDS = {
+  post: { xp: 10, currency: 5 },
+  comment: { xp: 5, currency: 2 },
+  reactionReceived: { xp: 3, currency: 1 }, // to the post author when someone reacts
+} as const;


### PR DESCRIPTION
Part 3 of 7. Stacked on #2.

Adds `core/progression.ts awardProgress()` — XP + currency to the user's primary character with level-ups via the shared leveling rules. Posting (+10/+5) and commenting (+5/+2) reward the actor; receiving a reaction rewards the post author (+3/+1), skipping self-reactions.

Files: core/progression.ts (new), api/social.ts. Base: pr2 branch.