### PR TITLE
6/7 Cross-platform sync foundation (schema + connectors)

### DIFF
--- a/migrations/0009_social_sync.sql
+++ b/migrations/0009_social_sync.sql
@@ -1,0 +1,35 @@
+-- Cross-platform sync: link external social accounts and import their content into fullstack.
+
+CREATE TABLE IF NOT EXISTS social_connections (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    user_id TEXT NOT NULL,
+    provider TEXT NOT NULL,            -- mastodon | rss | bluesky | twitter | facebook | instagram | custom
+    handle TEXT,                       -- @user@instance, feed URL, profile URL, etc.
+    external_account_id TEXT,
+    access_token TEXT,                 -- optional; set via secret-backed flows, not required for public sources
+    status TEXT NOT NULL DEFAULT 'active', -- active | error | revoked
+    last_synced_at TIMESTAMP,
+    last_error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE (user_id, provider, handle)
+);
+CREATE INDEX IF NOT EXISTS idx_social_connections_user ON social_connections(user_id);
+
+CREATE TABLE IF NOT EXISTS imported_posts (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    user_id TEXT NOT NULL,
+    connection_id TEXT,
+    provider TEXT NOT NULL,
+    external_id TEXT NOT NULL,         -- id of the post on the source platform
+    author_handle TEXT,
+    body TEXT,
+    url TEXT,
+    posted_at TIMESTAMP,
+    raw_json TEXT,
+    imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (connection_id) REFERENCES social_connections(id) ON DELETE CASCADE,
+    UNIQUE (provider, external_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_imported_posts_user ON imported_posts(user_id, posted_at);

--- a/workers/src/core/connectors.ts
+++ b/workers/src/core/connectors.ts
@@ -1,0 +1,108 @@
+/**
+ * Cross-platform connectors. A connector knows how to pull a normalized list of posts
+ * from an external source so they can be imported into fullstack's unified feed.
+ *
+ * Feasible-today connectors (no app review needed):
+ *   - mastodon: public statuses via the instance API
+ *   - rss:      any RSS/Atom feed (Substack, YouTube, blogs, many platforms expose one)
+ * Proprietary networks (twitter/x, facebook, instagram) require platform OAuth + app review,
+ * so they are represented as stubs plus the generic `push` import path (POST /api/sync/import).
+ */
+
+export interface NormalizedPost {
+  externalId: string;
+  authorHandle?: string;
+  body: string;
+  url?: string;
+  postedAt?: string; // ISO
+  raw?: unknown;
+}
+
+export interface ConnectorContext { handle: string; accessToken?: string | null; }
+export interface SocialConnector {
+  provider: string;
+  /** True if this connector can run without per-user OAuth/app review. */
+  selfServe: boolean;
+  fetchPosts(ctx: ConnectorContext): Promise<NormalizedPost[]>;
+}
+
+const stripHtml = (s: string) => s.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").trim();
+
+// ---- Mastodon (public) ----
+const mastodon: SocialConnector = {
+  provider: "mastodon",
+  selfServe: true,
+  async fetchPosts({ handle }) {
+    // handle: @user@instance  OR  user@instance
+    const m = handle.replace(/^@/, "").match(/^([^@]+)@(.+)$/);
+    if (!m) throw new Error("mastodon handle must look like user@instance.social");
+    const [, user, instance] = m;
+    const base = `https://${instance}`;
+    const lookup = await fetch(`${base}/api/v1/accounts/lookup?acct=${encodeURIComponent(user)}`, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!lookup.ok) throw new Error(`mastodon account lookup failed (${lookup.status})`);
+    const acct = (await lookup.json()) as { id: string };
+    const res = await fetch(`${base}/api/v1/accounts/${acct.id}/statuses?limit=20&exclude_replies=true`, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!res.ok) throw new Error(`mastodon statuses failed (${res.status})`);
+    const statuses = (await res.json()) as any[];
+    return statuses.map((s) => ({
+      externalId: String(s.id),
+      authorHandle: `@${user}@${instance}`,
+      body: stripHtml(s.content || ""),
+      url: s.url || s.uri,
+      postedAt: s.created_at,
+      raw: s,
+    }));
+  },
+};
+
+// ---- RSS / Atom (generic) ----
+const rss: SocialConnector = {
+  provider: "rss",
+  selfServe: true,
+  async fetchPosts({ handle }) {
+    if (!/^https?:\/\//.test(handle)) throw new Error("rss handle must be a feed URL");
+    const res = await fetch(handle, { headers: { "User-Agent": "fullstack-sync" } });
+    if (!res.ok) throw new Error(`rss fetch failed (${res.status})`);
+    const xml = await res.text();
+    const items = xml.split(/<item[\s>]/).slice(1).concat(xml.split(/<entry[\s>]/).slice(1));
+    const pick = (block: string, tag: string) => {
+      const m = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"));
+      return m ? m[1].replace(/<!\\[CDATA\\[|\\]\\]>/g, "").trim() : "";
+    };
+    return items.slice(0, 20).map((block, i) => {
+      const link = pick(block, "link") || (block.match(/<link[^>]*href="([^"]+)"/i)?.[1] ?? "");
+      const guid = pick(block, "guid") || link || String(i);
+      return {
+        externalId: guid,
+        body: stripHtml(pick(block, "title")) + (pick(block, "description") ? " — " + stripHtml(pick(block, "description")).slice(0, 280) : ""),
+        url: link,
+        postedAt: pick(block, "pubDate") || pick(block, "updated") || undefined,
+        raw: undefined,
+      };
+    });
+  },
+};
+
+// ---- Proprietary stubs (require OAuth + platform app review) ----
+function oauthStub(provider: string): SocialConnector {
+  return {
+    provider,
+    selfServe: false,
+    async fetchPosts() {
+      throw new Error(`${provider} requires OAuth + platform app review. Use POST /api/sync/import to push normalized posts from your ${provider} integration instead.`);
+    },
+  };
+}
+
+export const CONNECTORS: Record<string, SocialConnector> = {
+  mastodon,
+  rss,
+  bluesky: oauthStub("bluesky"),
+  twitter: oauthStub("twitter"),
+  facebook: oauthStub("facebook"),
+  instagram: oauthStub("instagram"),
+};
+
+export function getConnector(provider: string): SocialConnector | null {
+  return CONNECTORS[provider] ?? null;
+}


### PR DESCRIPTION
Part 6 of 7. Stacked on #5.

Migration `0009_social_sync.sql` (social_connections + imported_posts) and `core/connectors.ts` — connector interface with working Mastodon & RSS pull connectors plus OAuth stubs for bluesky/twitter/facebook/instagram.

Files: migrations/0009_social_sync.sql (new), core/connectors.ts (new). Base: pr5 branch.
After merge run: wrangler d1 execute <db> --remote --file=./migrations/0009_social_sync.sql