### PR TITLE
Redirect legacy /game/* URLs to /shade/*

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -22,6 +22,10 @@ export default [
   route("shade/battles/:id", "routes/battles.$id.tsx"),
   route("shade/leaderboard", "routes/game.leaderboard.tsx"),
 
+  // Legacy game URLs -> redirect to /shade/* (the game section was renamed)
+  route("game", "routes/game-redirect.tsx", { id: "game-redirect-root" }),
+  route("game/*", "routes/game-redirect.tsx", { id: "game-redirect-splat" }),
+
   // Auth callbacks
   route("auth/magic-link", "routes/auth.magic-link.tsx"),
 

--- a/app/routes/game-redirect.tsx
+++ b/app/routes/game-redirect.tsx
@@ -1,0 +1,15 @@
+import { redirect, type LoaderFunctionArgs } from "react-router";
+
+// Backwards-compatibility: the game section moved from /game/* to /shade/*.
+// Permanently redirect any old /game or /game/<rest> URL (bookmarks, external
+// links, search results) to the matching /shade path so they no longer 404.
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const splat = params["*"] ?? "";
+  const url = new URL(request.url);
+  const target = (splat ? `/shade/${splat}` : "/shade") + url.search + url.hash;
+  return redirect(target, 301);
+}
+
+export default function GameRedirect() {
+  return null;
+}


### PR DESCRIPTION
## Problem
The game section was renamed from `/game/*` to `/shade/*`. The new routes work in production (`/shade`, `/shade/dashboard`, etc. return `200`), but old `/game` and `/game/dashboard` URLs — bookmarks, external links, search results — return **404**.

No in-source links point to the old `/game` pages (every `/game/*` reference in the code is an API call to `/api/game/...`). The 404s are purely from stale external/bookmarked URLs.

## Fix
- Add `app/routes/game-redirect.tsx` — a loader that `301`-redirects `/game/<anything>` → `/shade/<anything>`, preserving query string and hash.
- Wire `game` and `game/*` to it in `app/routes.ts`.

## Verification
- `/shade` subpaths and the old `/game` subpaths share the same names (`dashboard`, `battle`, `players`, `battles/:id`, `leaderboard`), so a straight prefix swap is correct.
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)