### PR TITLE
Add create/change password in account settings

### DIFF
--- a/app/lib/AuthContext.tsx
+++ b/app/lib/AuthContext.tsx
@@ -10,6 +10,7 @@ interface User {
   avatar_url?: string;
   cover_photo_url?: string;
   bio?: string;
+  has_password?: boolean;
 }
 
 interface AuthContextType {

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,5 +1,130 @@
 import { Link } from "react-router-dom";
+import { useState } from "react";
 import { useAuth } from "../lib/AuthContext";
+import { apiClient } from "../lib/api";
+
+function PasswordSection({ hasPassword }: { hasPassword: boolean }) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+
+    if (newPassword.length < 8) {
+      setMessage({ type: "error", text: "New password must be at least 8 characters." });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setMessage({ type: "error", text: "Passwords do not match." });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await apiClient.post("/auth/password/change", {
+        ...(hasPassword ? { currentPassword } : {}),
+        newPassword,
+      });
+      setMessage({
+        type: "success",
+        text: hasPassword ? "Password changed successfully." : "Password created successfully.",
+      });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err) {
+      setMessage({ type: "error", text: err instanceof Error ? err.message : "Something went wrong." });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    "w-full px-3 py-2 rounded-lg bg-social-cream-100 border border-social-cream-300 text-social-forest-700 focus:outline-none focus:ring-2 focus:ring-social-gold-400";
+
+  return (
+    <section className="social-panel rounded-2xl p-5 shadow">
+      <h2 className="text-xl font-semibold text-social-forest-700 mb-1">
+        {hasPassword ? "Change Password" : "Create Password"}
+      </h2>
+      <p className="text-sm text-social-forest-500 mb-4">
+        {hasPassword
+          ? "Update the password you use to sign in."
+          : "Your account currently signs in with Google or a magic link. Set a password to also sign in with email and password."}
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {hasPassword && (
+          <div>
+            <label className="block text-sm text-social-forest-500 mb-1" htmlFor="current-password">
+              Current password
+            </label>
+            <input
+              id="current-password"
+              type="password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className={inputClass}
+              required
+            />
+          </div>
+        )}
+        <div>
+          <label className="block text-sm text-social-forest-500 mb-1" htmlFor="new-password">
+            New password
+          </label>
+          <input
+            id="new-password"
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className={inputClass}
+            minLength={8}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-social-forest-500 mb-1" htmlFor="confirm-password">
+            Confirm new password
+          </label>
+          <input
+            id="confirm-password"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className={inputClass}
+            minLength={8}
+            required
+          />
+        </div>
+
+        {message && (
+          <p
+            className={`text-sm ${
+              message.type === "success" ? "text-social-green-600" : "text-red-600"
+            }`}
+          >
+            {message.text}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full bg-gradient-to-r from-social-forest-600 to-social-forest-800 text-social-cream-100 px-6 py-2.5 rounded-lg font-semibold hover:from-social-forest-700 hover:to-social-forest-900 transition-all shadow disabled:opacity-60"
+        >
+          {submitting ? "Saving…" : hasPassword ? "Change Password" : "Create Password"}
+        </button>
+      </form>
+    </section>
+  );
+}
 
 export default function SettingsPage() {
   const { isAuthenticated, user } = useAuth();
@@ -55,6 +180,9 @@ export default function SettingsPage() {
           </div>
         </div>
       </section>
+
+      {/* Password - create or change */}
+      <PasswordSection hasPassword={!!user?.has_password} />
 
       {/* Game Access - Hidden gateway to the game */}
       <section className="social-panel rounded-2xl p-5 shadow border-2 border-social-gold-400">

--- a/workers/src/api/auth.ts
+++ b/workers/src/api/auth.ts
@@ -5,7 +5,7 @@ import type { Bindings } from '../bindings';
 import { loginSchema, registerSchema } from '../shared/schemas/auth';
 import { googleAuthSchema } from '../shared/schemas/google';
 import { magicLinkRequestSchema, magicLinkVerifySchema } from '../shared/schemas/magic-link';
-import { passwordResetRequestSchema, passwordResetSchema } from '../shared/schemas/password-reset';
+import { passwordResetRequestSchema, passwordResetSchema, passwordChangeSchema } from '../shared/schemas/password-reset';
 import { hashPassword, verifyPassword } from '../lib/auth';
 import { createSession } from '../lib/session';
 import { rollInitialCharacter, sanitizeGamertag } from '../core/classes';
@@ -639,6 +639,60 @@ auth.post('/password-reset/reset', zValidator('json', passwordResetSchema), asyn
     return c.json({ message: 'Password reset successfully. Please log in with your new password.' });
   } catch (error) {
     console.error('Password reset error:', error);
+    return c.json({ error: 'An internal error occurred' }, 500);
+  }
+});
+
+// Change or create the current user's password (from account settings).
+// Accounts created via Google / magic link have no password yet, so this also
+// serves as "create a password" — in that case currentPassword is not required.
+auth.post('/password/change', authMiddleware, zValidator('json', passwordChangeSchema), async (c) => {
+  const authUser = c.get('user') as { id: string };
+  const { currentPassword, newPassword } = c.req.valid('json');
+  const db = c.env.DB;
+
+  try {
+    const row = await db
+      .prepare('SELECT password_hash FROM users WHERE id = ?')
+      .bind(authUser.id)
+      .first<{ password_hash: string | null }>();
+
+    if (!row) {
+      return c.json({ error: 'User not found' }, 404);
+    }
+
+    const hadPassword = !!row.password_hash;
+
+    // If the account already has a password, the current one must be supplied and correct.
+    if (hadPassword) {
+      if (!currentPassword) {
+        return c.json({ error: 'Current password is required' }, 400);
+      }
+      const ok = await verifyPassword(currentPassword, row.password_hash!);
+      if (!ok) {
+        return c.json({ error: 'Current password is incorrect' }, 401);
+      }
+    }
+
+    const newHash = await hashPassword(newPassword);
+    await db.prepare('UPDATE users SET password_hash = ? WHERE id = ?')
+      .bind(newHash, authUser.id)
+      .run();
+
+    // Invalidate other sessions for security, but keep the caller logged in.
+    const currentToken = getCookie(c, 'session_token');
+    if (currentToken) {
+      const keepHash = await hashToken(currentToken);
+      await db.prepare('DELETE FROM sessions WHERE user_id = ? AND token_hash != ?')
+        .bind(authUser.id, keepHash)
+        .run();
+    }
+
+    return c.json({
+      message: hadPassword ? 'Password changed successfully' : 'Password created successfully',
+    });
+  } catch (error) {
+    console.error('Password change error:', error);
     return c.json({ error: 'An internal error occurred' }, 500);
   }
 });

--- a/workers/src/api/index.ts
+++ b/workers/src/api/index.ts
@@ -17,7 +17,9 @@ api.get('/', (c) => {
 // plain-text 404 (which the frontend surfaces as "Invalid response from server").
 function lazyRoute(
   basePath: string,
-  importer: () => Promise<{ default: Hono<{ Bindings: Bindings }> }>,
+  // Sub-routers vary in their Variables (some add `user` via auth middleware),
+  // so accept any Hono instance here — we only call its `fetch`.
+  importer: () => Promise<{ default: Hono<any, any, any> }>,
 ) {
   return new Hono<{ Bindings: Bindings }>().all('*', async (c) => {
     const { default: routes } = await importer();

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -41,8 +41,9 @@ users.get('/me', authMiddleware, async (c) => {
   const db = c.env.DB;
 
   const character = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(user.id).first<{id: string}>();
+  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password FROM users WHERE id = ?').bind(user.id).first<{ has_password: number }>();
 
-  return c.json({ data: { ...user, characterId: character?.id } });
+  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password } });
 });
 
 // PUT /api/users/me - Update the current authenticated user's profile

--- a/workers/src/shared/schemas/password-reset.ts
+++ b/workers/src/shared/schemas/password-reset.ts
@@ -8,3 +8,11 @@ export const passwordResetSchema = z.object({
   token: z.string().min(10),
   password: z.string().min(8, 'Password must be at least 8 characters'),
 });
+
+// Used from account settings by a logged-in user to create or change their
+// password. currentPassword is required only when the account already has one
+// (accounts created via Google / magic link have no password to verify).
+export const passwordChangeSchema = z.object({
+  currentPassword: z.string().optional(),
+  newPassword: z.string().min(8, 'Password must be at least 8 characters'),
+});


### PR DESCRIPTION
## What
Lets logged-in users set or change their account password from **Settings**.

## Why
Accounts created via Google / magic link have no password, so they could only ever use those methods. This adds a self-service way to create a password (and to change an existing one).

## Changes
- **`POST /api/auth/password/change`** (authenticated):
  - If the account already has a password → `currentPassword` required and verified.
  - If it has none (Google / magic link) → acts as "create password", no current password needed.
  - On success, invalidates the user's *other* sessions while keeping the caller signed in.
- **`GET /api/users/me`** now returns `has_password` so the UI shows "Create" vs "Change".
- **Settings page**: new Password section with current/new/confirm fields, client-side validation (length + match), and success/error feedback.

## Verification
- `npm run build` ✅
- `npm run typecheck` ✅ (0 TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)