### PR TITLE
Fix multi-slot stat allocation, persist shade avatars, add gamer profile

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -29,6 +29,7 @@ export function NavBar() {
           </Link>
           <div className="flex items-center space-x-6">
             <Link to="/shade/dashboard" className="text-shade-red-200 hover:text-shade-red-600 transition-colors duration-200">Dashboard</Link>
+            <Link to="/shade/profile" className="text-shade-red-200 hover:text-shade-red-600 transition-colors duration-200">Profile</Link>
             <Link to="/shade/battle" className="text-shade-red-200 hover:text-shade-red-600 transition-colors duration-200">Battle</Link>
             <Link to="/shade/players" className="text-shade-red-200 hover:text-shade-red-600 transition-colors duration-200">Find Players</Link>
             <Link to="/shade/leaderboard" className="text-shade-red-200 hover:text-shade-red-600 transition-colors duration-200">Leaderboard</Link>

--- a/app/lib/AuthContext.tsx
+++ b/app/lib/AuthContext.tsx
@@ -11,6 +11,7 @@ interface User {
   cover_photo_url?: string;
   bio?: string;
   has_password?: boolean;
+  shade_avatar_url?: string | null;
 }
 
 interface AuthContextType {
@@ -18,6 +19,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   login: (user: User) => void;
   logout: () => void;
+  refreshUser: () => Promise<void>;
   isLoading: boolean;
 }
 
@@ -46,6 +48,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(userData);
   };
 
+  const refreshUser = async () => {
+    try {
+      const response = await apiClient.get<{ data: User }>('/users/me');
+      setUser(response.data);
+    } catch (error) {
+      // Keep the existing user on a transient failure.
+    }
+  };
+
   const logout = async () => {
     try {
         await apiClient.post('/auth/logout', {});
@@ -57,7 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated: !!user, login, logout, isLoading }}>
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, login, logout, refreshUser, isLoading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -17,6 +17,7 @@ export default [
   // Game Routes (under /shade prefix)
   route("shade", "routes/shade.index.tsx"),  // Game landing/login page
   route("shade/dashboard", "routes/game.dashboard.tsx"),
+  route("shade/profile", "routes/shade.profile.tsx"),
   route("shade/battle", "routes/game.storm8.tsx"),
   route("shade/players", "routes/game.players.tsx"),
   route("shade/battles/:id", "routes/battles.$id.tsx"),

--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { apiClient } from '../lib/api';
+import { useAuth } from '../lib/AuthContext';
 import { SquarePayment } from '../components/SquarePayment';
 
 type SlotInfo = {
@@ -302,7 +303,7 @@ function AllocatePointsForm({
       return;
     }
     try {
-      await apiClient.post('/game/character/allocate-points', points);
+      await apiClient.post('/game/character/allocate-points', { characterId: character.id, ...points });
       setPoints({ hp: 0, atk: 0, def: 0, mp: 0, spd: 0 });
       onAllocationComplete();
     } catch (err: any) {
@@ -425,6 +426,7 @@ function PurchaseSlotModal({
 }
 
 export default function GameDashboardPage() {
+  const { user } = useAuth();
   const [slotInfo, setSlotInfo] = useState<SlotInfo | null>(null);
   const [character, setCharacter] = useState<Character | null>(null);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
@@ -619,6 +621,12 @@ export default function GameDashboardPage() {
         >
           Dashboard
         </button>
+        <Link
+          to="/shade/profile"
+          className="px-4 py-2 bg-shade-black-800 border border-shade-red-800 text-shade-red-400 rounded hover:border-shade-red-600 transition-all"
+        >
+          Gamer Profile
+        </Link>
         <button
           onClick={() => setView('story')}
           className="px-4 py-2 bg-shade-black-800 border border-shade-red-800 text-shade-red-400 rounded hover:border-shade-red-600 transition-all"
@@ -629,7 +637,20 @@ export default function GameDashboardPage() {
 
       {character && character.first_game_access_completed ? (
         <>
-          <h1 className="text-2xl font-bold mb-4 neon-text">Welcome, {character.gamertag}!</h1>
+          <div className="flex items-center gap-4 mb-4">
+            <Link
+              to="/shade/profile"
+              className="w-14 h-14 rounded-full overflow-hidden silhouette-avatar breathing-glow flex items-center justify-center shrink-0"
+              title="View gamer profile"
+            >
+              {user?.shade_avatar_url ? (
+                <img src={user.shade_avatar_url} alt="Shade avatar" className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-xl neon-text">{character.gamertag?.charAt(0).toUpperCase()}</span>
+              )}
+            </Link>
+            <h1 className="text-2xl font-bold neon-text">Welcome, {character.gamertag}!</h1>
+          </div>
           {character.unspent_stat_points > 0 && (
             <AllocatePointsForm
               character={character}

--- a/app/routes/shade.index.tsx
+++ b/app/routes/shade.index.tsx
@@ -4,19 +4,26 @@ import { useAuth } from "../lib/AuthContext";
 import { apiClient } from "../lib/api";
 
 export default function ShadeIndexPage() {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, refreshUser } = useAuth();
   const [shadeAvatar, setShadeAvatar] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
 
   const generateShadeAvatar = async () => {
     setIsGenerating(true);
     setError(null);
+    setSaved(false);
 
     try {
-      const result = await apiClient.post<{ image: string; success: boolean }>("/ai/shade-avatar", {});
+      const result = await apiClient.post<{ image: string; url?: string; success: boolean }>("/ai/shade-avatar", {});
       if (result.image) {
         setShadeAvatar(result.image);
+      }
+      if (result.url) {
+        // Persisted server-side; refresh context so it shows across the game.
+        setSaved(true);
+        await refreshUser();
       }
     } catch (err: any) {
       setError(err?.message || "Failed to generate shade avatar");
@@ -27,10 +34,12 @@ export default function ShadeIndexPage() {
 
   // Determine what to show in the avatar circle
   const getAvatarContent = () => {
-    if (shadeAvatar) {
+    // Freshly generated this session, or previously saved shade avatar.
+    const shadeSrc = shadeAvatar || user?.shade_avatar_url;
+    if (shadeSrc) {
       return (
         <img
-          src={shadeAvatar}
+          src={shadeSrc}
           alt="Your Shade"
           className="w-full h-full object-cover rounded-full"
         />
@@ -79,9 +88,13 @@ export default function ShadeIndexPage() {
                 disabled={isGenerating}
                 className="text-xs px-3 py-1 bg-shade-black-800 neon-border text-shade-red-400 rounded hover:neon-glow transition-all disabled:opacity-50"
               >
-                Generate Shade Avatar
+                {user?.shade_avatar_url || shadeAvatar ? "Regenerate Shade Avatar" : "Generate Shade Avatar"}
               </button>
             </div>
+          )}
+
+          {saved && (
+            <p className="text-xs text-shade-red-400 mb-4">Saved to your profile ✓</p>
           )}
 
           {error && (

--- a/app/routes/shade.profile.tsx
+++ b/app/routes/shade.profile.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { apiClient } from "../lib/api";
+import { useAuth } from "../lib/AuthContext";
+
+type GamerCharacter = {
+  id: string;
+  slot_number: number;
+  gamertag: string | null;
+  class: string | null;
+  level: number;
+  xp: number;
+  hp: number;
+  atk: number;
+  def: number;
+  mp: number;
+  spd: number;
+  unspent_stat_points: number;
+  first_game_access_completed: boolean;
+  wins: number | null;
+  losses: number | null;
+  kills: number | null;
+  deaths: number | null;
+};
+
+type GamerProfile = {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  shade_avatar_url: string | null;
+  created_at: string | null;
+};
+
+const STAT_KEYS: { key: keyof GamerCharacter; label: string }[] = [
+  { key: "hp", label: "HP" },
+  { key: "atk", label: "ATK" },
+  { key: "def", label: "DEF" },
+  { key: "mp", label: "MP" },
+  { key: "spd", label: "SPD" },
+];
+
+function CharacterPanel({ char }: { char: GamerCharacter }) {
+  const winRate = (() => {
+    const w = char.wins ?? 0;
+    const l = char.losses ?? 0;
+    const total = w + l;
+    return total === 0 ? "—" : `${Math.round((w / total) * 100)}%`;
+  })();
+
+  return (
+    <div className="beveled-panel p-5 rounded-lg">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <div className="text-xs text-shade-red-400">Slot {char.slot_number}</div>
+          <h3 className="text-xl font-bold neon-text">{char.gamertag || "Unnamed"}</h3>
+          <div className="text-sm text-shade-red-300">
+            {char.class ? `${char.class} • Lv.${char.level}` : "Setup incomplete"}
+          </div>
+        </div>
+        {char.unspent_stat_points > 0 && (
+          <Link
+            to="/shade/dashboard"
+            className="text-xs px-3 py-1 bg-shade-black-900 neon-border text-shade-red-500 rounded hover:neon-glow transition-all"
+            title="Allocate unspent points"
+          >
+            {char.unspent_stat_points.toLocaleString()} unspent →
+          </Link>
+        )}
+      </div>
+
+      <div className="mb-3">
+        <div className="text-xs text-shade-red-400 mb-1">
+          {char.xp.toLocaleString()} XP
+        </div>
+      </div>
+
+      <div className="grid grid-cols-5 gap-2 mb-4">
+        {STAT_KEYS.map(({ key, label }) => (
+          <div key={label} className="text-center bg-shade-black-800 rounded p-2">
+            <div className="text-[10px] uppercase text-shade-red-400">{label}</div>
+            <div className="text-shade-red-100 font-semibold">
+              {(char[key] as number).toLocaleString()}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 text-center">
+        <div>
+          <div className="text-[10px] uppercase text-shade-red-400">Wins</div>
+          <div className="text-shade-red-100">{char.wins ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase text-shade-red-400">Losses</div>
+          <div className="text-shade-red-100">{char.losses ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase text-shade-red-400">Kills</div>
+          <div className="text-shade-red-100">{char.kills ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase text-shade-red-400">W/L</div>
+          <div className="text-shade-red-100">{winRate}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function GamerProfilePage() {
+  const { isAuthenticated, refreshUser } = useAuth();
+  const [profile, setProfile] = useState<GamerProfile | null>(null);
+  const [characters, setCharacters] = useState<GamerCharacter[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  const load = async () => {
+    try {
+      const res = await apiClient.get<{ data: { profile: GamerProfile; characters: GamerCharacter[] } }>(
+        "/game/profile"
+      );
+      setProfile(res.data.profile);
+      setCharacters(res.data.characters || []);
+    } catch (err: any) {
+      setError(err?.message || "Failed to load profile");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      load();
+    } else {
+      setLoading(false);
+    }
+  }, [isAuthenticated]);
+
+  const regenerateAvatar = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      await apiClient.post("/ai/shade-avatar", {});
+      await Promise.all([load(), refreshUser()]);
+    } catch (err: any) {
+      setError(err?.message || "Failed to generate avatar");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-3xl mx-auto p-6 text-center">
+        <p className="text-shade-red-300 mb-4">Log in to view your gamer profile.</p>
+        <Link to="/login" className="bg-shade-black-900 neon-border text-shade-red-600 px-6 py-2 rounded hover:neon-glow transition-all">
+          Login
+        </Link>
+      </div>
+    );
+  }
+
+  if (loading) return <div className="neon-text p-6">Loading profile…</div>;
+
+  const avatarSrc = profile?.shade_avatar_url || profile?.avatar_url || null;
+  const completedChars = characters.filter((c) => c.first_game_access_completed);
+  const topLevel = completedChars.reduce((max, c) => Math.max(max, c.level), 0);
+  const totalWins = completedChars.reduce((sum, c) => sum + (c.wins ?? 0), 0);
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-6">
+      {/* Profile header */}
+      <div className="beveled-panel p-6 rounded-lg flex flex-col sm:flex-row items-center gap-6">
+        <div className="w-28 h-28 rounded-full overflow-hidden silhouette-avatar breathing-glow flex items-center justify-center shrink-0">
+          {avatarSrc ? (
+            <img src={avatarSrc} alt="Shade avatar" className="w-full h-full object-cover" />
+          ) : (
+            <span className="text-4xl neon-text">{profile?.username?.charAt(0).toUpperCase()}</span>
+          )}
+        </div>
+        <div className="flex-1 text-center sm:text-left">
+          <h1 className="text-3xl font-bold neon-text-strong">{profile?.username}</h1>
+          <p className="text-shade-red-300 text-sm mt-1">
+            {completedChars.length} character{completedChars.length === 1 ? "" : "s"} • Top level {topLevel || "—"} • {totalWins.toLocaleString()} total wins
+          </p>
+          <div className="flex gap-2 justify-center sm:justify-start mt-4">
+            <button
+              onClick={regenerateAvatar}
+              disabled={generating}
+              className="text-xs px-3 py-1.5 bg-shade-black-800 neon-border text-shade-red-400 rounded hover:neon-glow transition-all disabled:opacity-50"
+            >
+              {generating ? "Generating…" : avatarSrc ? "Regenerate Avatar" : "Generate Avatar"}
+            </button>
+            <Link
+              to="/shade/dashboard"
+              className="text-xs px-3 py-1.5 bg-shade-black-900 neon-border text-shade-red-500 rounded hover:neon-glow transition-all"
+            >
+              Dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {error && <p className="text-shade-red-500 text-sm">{error}</p>}
+
+      {/* Characters */}
+      <div>
+        <h2 className="text-lg font-bold neon-text mb-3">Characters</h2>
+        {completedChars.length === 0 ? (
+          <div className="beveled-panel p-6 text-center text-shade-red-300">
+            No characters yet.{" "}
+            <Link to="/shade/dashboard" className="neon-text underline">
+              Create one
+            </Link>
+            .
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {completedChars.map((char) => (
+              <CharacterPanel key={char.id} char={char} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/migrations/0010_game_profile.sql
+++ b/migrations/0010_game_profile.sql
@@ -1,0 +1,5 @@
+-- Gamer profile: store the AI-generated "shade" avatar so it persists and can
+-- be shown across the game (dashboard, gamer profile) instead of only living in
+-- transient client state.
+
+ALTER TABLE users ADD COLUMN shade_avatar_url TEXT;

--- a/workers/src/api/ai.ts
+++ b/workers/src/api/ai.ts
@@ -13,8 +13,11 @@ const shadePrompts = [
   'phantom silhouette portrait, blood red neon outline, dark aesthetic, pure black background, ghostly figure, high contrast avatar',
 ];
 
-// Helper to convert stream to base64
-async function streamToBase64(stream: ReadableStream): Promise<string> {
+// R2 public URL base (custom domain, same as the upload routes).
+const SHADE_IMAGE_BASE = 'https://shade-image.hwmnbn.me';
+
+// Collect a ReadableStream into a single Uint8Array.
+async function streamToBytes(stream: ReadableStream): Promise<Uint8Array> {
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
 
@@ -31,13 +34,44 @@ async function streamToBase64(stream: ReadableStream): Promise<string> {
     combined.set(chunk, offset);
     offset += chunk.length;
   }
-
-  return btoa(String.fromCharCode(...combined));
+  return combined;
 }
 
-// Generate a shade-themed avatar (text-to-image)
+// Base64-encode bytes in chunks (avoids blowing the call stack on large images).
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+// Persist a generated avatar to R2 and save its URL on the user. Returns the
+// public URL, or undefined if persistence failed (generation still succeeds).
+async function persistShadeAvatar(
+  env: Bindings,
+  userId: string,
+  bytes: Uint8Array,
+): Promise<string | undefined> {
+  try {
+    const key = `shade-avatars/${userId}/${Date.now()}.png`;
+    await env.MEDIA.put(key, bytes, { httpMetadata: { contentType: 'image/png' } });
+    const url = `${SHADE_IMAGE_BASE}/${key}`;
+    await env.DB.prepare('UPDATE users SET shade_avatar_url = ? WHERE id = ?').bind(url, userId).run();
+    return url;
+  } catch (err: any) {
+    console.warn('Failed to persist shade avatar:', err?.message || err);
+    return undefined;
+  }
+}
+
+// Generate a shade-themed avatar (text-to-image), persist it, and return both
+// an inline data URL (instant preview) and the saved public URL.
 ai.post('/shade-avatar', authMiddleware, async (c) => {
   try {
+    const userId = (c.get('user') as { id: string } | undefined)?.id;
+
     // Pick a random shade prompt variation
     const randomPrompt = shadePrompts[Math.floor(Math.random() * shadePrompts.length)];
 
@@ -50,9 +84,11 @@ ai.post('/shade-avatar', authMiddleware, async (c) => {
     );
 
     if (result instanceof ReadableStream) {
-      const base64 = await streamToBase64(result);
+      const bytes = await streamToBytes(result);
+      const url = userId ? await persistShadeAvatar(c.env, userId, bytes) : undefined;
       return c.json({
-        image: `data:image/png;base64,${base64}`,
+        image: `data:image/png;base64,${bytesToBase64(bytes)}`,
+        url,
         success: true
       });
     }
@@ -67,6 +103,7 @@ ai.post('/shade-avatar', authMiddleware, async (c) => {
 // Generate shade avatar with optional custom prompt additions
 ai.post('/generate-shade-avatar', authMiddleware, async (c) => {
   try {
+    const userId = (c.get('user') as { id: string } | undefined)?.id;
     const body: { prompt?: string; style?: string } = await c.req.json().catch(() => ({}));
     const customAddition = body.prompt || '';
     const style = body.style || 'random';
@@ -90,9 +127,11 @@ ai.post('/generate-shade-avatar', authMiddleware, async (c) => {
     );
 
     if (result instanceof ReadableStream) {
-      const base64 = await streamToBase64(result);
+      const bytes = await streamToBytes(result);
+      const url = userId ? await persistShadeAvatar(c.env, userId, bytes) : undefined;
       return c.json({
-        image: `data:image/png;base64,${base64}`,
+        image: `data:image/png;base64,${bytesToBase64(bytes)}`,
+        url,
         success: true
       });
     }

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -391,6 +391,28 @@ game.get('/my-characters', async (c) => {
     return c.json({ data: characters.results || [] });
 });
 
+// Aggregate gamer profile: the player's game identity plus all their characters
+// (with trophies). Backs the dedicated gamer profile page.
+game.get('/profile', async (c) => {
+    const user = c.get('user');
+    const db = c.env.DB;
+
+    const profile = await db
+        .prepare('SELECT id, username, avatar_url, shade_avatar_url, created_at FROM users WHERE id = ?')
+        .bind(user.id)
+        .first();
+
+    const characters = await db.prepare(`
+        SELECT c.*, t.wins, t.losses, t.kills, t.deaths
+        FROM characters c
+        LEFT JOIN trophies t ON c.id = t.character_id
+        WHERE c.user_id = ?
+        ORDER BY c.slot_number
+    `).bind(user.id).all();
+
+    return c.json({ data: { profile, characters: characters.results || [] } });
+});
+
 // Get character details (optionally by slot number)
 game.get('/character', async (c) => {
     const user = c.get('user');
@@ -464,15 +486,20 @@ import { allocatePointsSchema } from '../shared/schemas/game';
 // Allocate stat points
 game.post('/character/allocate-points', zValidator('json', allocatePointsSchema), async (c) => {
     const user = c.get('user');
-    const pointsToAllocate = c.req.valid('json');
+    const { characterId, ...pointsToAllocate } = c.req.valid('json');
     const db = c.env.DB;
 
     const totalPointsToSpend = Object.values(pointsToAllocate).reduce((sum, val) => sum + val, 0);
 
-    const character = await db.prepare('SELECT id, unspent_stat_points FROM characters WHERE user_id = ?').bind(user.id).first<{id: string, unspent_stat_points: number}>();
+    // Target the specific character the user is editing (and verify ownership),
+    // rather than whichever character happens to come back first.
+    const character = await db
+        .prepare('SELECT id, unspent_stat_points FROM characters WHERE id = ? AND user_id = ?')
+        .bind(characterId, user.id)
+        .first<{id: string, unspent_stat_points: number}>();
 
     if (!character) {
-        return c.json({ error: 'Character not found.' }, 404);
+        return c.json({ error: 'Character not found or does not belong to you.' }, 404);
     }
 
     if (totalPointsToSpend <= 0 || totalPointsToSpend > character.unspent_stat_points) {

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -41,9 +41,9 @@ users.get('/me', authMiddleware, async (c) => {
   const db = c.env.DB;
 
   const character = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(user.id).first<{id: string}>();
-  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password FROM users WHERE id = ?').bind(user.id).first<{ has_password: number }>();
+  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password, shade_avatar_url FROM users WHERE id = ?').bind(user.id).first<{ has_password: number; shade_avatar_url: string | null }>();
 
-  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password } });
+  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password, shade_avatar_url: account?.shade_avatar_url ?? null } });
 });
 
 // PUT /api/users/me - Update the current authenticated user's profile

--- a/workers/src/shared/schemas/game.ts
+++ b/workers/src/shared/schemas/game.ts
@@ -14,6 +14,7 @@ export const firstAccessSchema = z.object({
 });
 
 export const allocatePointsSchema = z.object({
+    characterId: z.string().uuid({ message: 'Invalid character ID' }),
     hp: z.number().int().min(0).default(0),
     atk: z.number().int().min(0).default(0),
     def: z.number().int().min(0).default(0),


### PR DESCRIPTION
Addresses three reported issues with the game (`/shade`) section.

## 1. Can't allocate points to a non-slot-1 character (bug)
`POST /game/character/allocate-points` selected the character with `WHERE user_id = ?` + `.first()`, so it **always targeted slot 1** regardless of which character you were editing. Allocating to slot 2 silently failed because slot 1 had 0 unspent points → "Invalid number of points to allocate."

**Fix:** `allocatePointsSchema` now requires `characterId`; the endpoint targets that character with an ownership check (`WHERE id = ? AND user_id = ?`); the dashboard form sends the selected `character.id`.

## 2. Generated avatar never showed anywhere
The "shade" avatar was returned as a base64 data URL and only kept in component state, so it vanished on navigation and never appeared in-game.

**Fix:** `/ai/shade-avatar` (and `/generate-shade-avatar`) now upload the PNG to R2 (`shade-image.hwmnbn.me`) and save the URL on the user. New `users.shade_avatar_url` column (**migration 0010**, already applied to remote). `/users/me` returns it; `AuthContext` gains `refreshUser()` so it propagates immediately.

## 3. "I need a gamer profile, not just a dashboard"
New **`/shade/profile`** page: shade avatar, username, summary (character count, top level, total wins), and a panel per character (class, level, XP, full HP/ATK/DEF/MP/SPD, trophies, win rate). Backed by new **`GET /game/profile`**. Linked from the shade NavBar and the dashboard (which also shows the avatar by the welcome line).

## Verification
- `npm run build` ✅  •  `npm run typecheck` ✅ (0 errors)
- Migration 0010 applied to `social_rpg_db` (remote).
- Post-deploy: will verify slot-2 allocation end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)