### PR TITLE
Per-user voice conversation storage (KV) + account deletion

### DIFF
--- a/app/lib/VoiceAssistantContext.tsx
+++ b/app/lib/VoiceAssistantContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useState, useContext, useRef, useCallback } from 'react';
+import { createContext, useState, useContext, useRef, useCallback, useEffect } from 'react';
 import type { ReactNode } from 'react';
+import { useAuth } from './AuthContext';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -56,6 +57,8 @@ interface VoiceAssistantContextType {
 const VoiceAssistantContext = createContext<VoiceAssistantContextType | undefined>(undefined);
 
 export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth();
+
   // UI State
   const [isOpen, setIsOpen] = useState(false);
   const [isListening, setIsListening] = useState(false);
@@ -76,6 +79,43 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
   const audioElementRef = useRef<HTMLAudioElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
 
+  // Persist the conversation to the user's KV-backed history (best effort).
+  const persistHistory = useCallback(async (msgs: ChatMessage[]) => {
+    try {
+      await fetch('/api/voice/history', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: msgs }),
+      });
+    } catch {
+      // Non-fatal: the conversation still works in-session.
+    }
+  }, []);
+
+  // Restore the saved conversation when the user is authenticated.
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setMessages([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/voice/history');
+        if (!res.ok) return;
+        const data = (await res.json()) as { messages?: ChatMessage[] };
+        if (!cancelled && Array.isArray(data.messages)) {
+          setMessages(data.messages);
+        }
+      } catch {
+        // Ignore — start with an empty conversation.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
   const toggleOpen = useCallback(() => {
     setIsOpen((prev) => !prev);
     setError(null);
@@ -90,6 +130,8 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
     setCurrentTranscript('');
     setAudioUrl(null);
     setError(null);
+    // Also clear the saved copy in KV.
+    fetch('/api/voice/history', { method: 'DELETE' }).catch(() => {});
   }, []);
 
   const stopAudio = useCallback(() => {
@@ -145,7 +187,11 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
 
       // Add messages to conversation
       if (data.messages) {
-        setMessages((prev) => [...prev, ...data.messages]);
+        setMessages((prev) => {
+          const updated = [...prev, ...data.messages];
+          persistHistory(updated);
+          return updated;
+        });
       }
 
       // Set audio for playback
@@ -167,7 +213,7 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsProcessing(false);
     }
-  }, [messages]);
+  }, [messages, persistHistory]);
 
   const startListening = useCallback(async () => {
     setError(null);
@@ -263,7 +309,11 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
         role: 'assistant',
         content: data.response,
       };
-      setMessages((prev) => [...prev, assistantMessage]);
+      setMessages((prev) => {
+        const updated = [...prev, assistantMessage];
+        persistHistory(updated);
+        return updated;
+      });
 
       // Synthesize response to speech
       const ttsResponse = await fetch('/api/voice/synthesize', {
@@ -299,7 +349,7 @@ export function VoiceAssistantProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsProcessing(false);
     }
-  }, [messages]);
+  }, [messages, persistHistory]);
 
   // Create audio element on mount
   if (typeof window !== 'undefined' && !audioElementRef.current) {

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,7 +1,60 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useAuth } from "../lib/AuthContext";
 import { apiClient } from "../lib/api";
+
+function DeleteAccountSection() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setError(null);
+    setDeleting(true);
+    try {
+      await apiClient.delete("/users/me");
+      // Account (and its data) is gone — clear local session and leave.
+      await logout();
+      navigate("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete account.");
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <section className="social-panel rounded-2xl p-5 shadow border border-red-300">
+      <h2 className="text-xl font-semibold text-red-700 mb-1">Delete Account</h2>
+      <p className="text-sm text-social-forest-500 mb-4">
+        Permanently delete your account and all associated data — your profile, posts, friends,
+        game characters, uploaded images, and your saved voice assistant conversations. This cannot
+        be undone.
+      </p>
+      <label className="block text-sm text-social-forest-500 mb-1" htmlFor="delete-confirm">
+        Type <span className="font-semibold text-red-700">DELETE</span> to confirm
+      </label>
+      <input
+        id="delete-confirm"
+        type="text"
+        value={confirmText}
+        onChange={(e) => setConfirmText(e.target.value)}
+        className="w-full px-3 py-2 rounded-lg bg-social-cream-100 border border-red-200 text-social-forest-700 focus:outline-none focus:ring-2 focus:ring-red-400 mb-3"
+        placeholder="DELETE"
+      />
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={confirmText !== "DELETE" || deleting}
+        className="w-full bg-red-600 text-white px-6 py-2.5 rounded-lg font-semibold hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {deleting ? "Deleting…" : "Delete My Account"}
+      </button>
+    </section>
+  );
+}
 
 function PasswordSection({ hasPassword }: { hasPassword: boolean }) {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -206,6 +259,9 @@ export default function SettingsPage() {
           <Link to="/privacy" className="text-social-green-600 hover:underline">View Privacy Policy</Link>
         </div>
       </section>
+
+      {/* Danger zone */}
+      <DeleteAccountSection />
       </div>
     </div>
   );

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -1,9 +1,21 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { deleteCookie } from 'hono/cookie';
 import type { Bindings } from '../bindings';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedUser } from './middleware/auth';
 import { updateProfileSchema } from '../shared/schemas/profile';
+
+// Best-effort delete of an R2 object given its public URL (avatars/covers).
+async function deleteMediaByUrl(env: Bindings, url: string | null | undefined): Promise<void> {
+  if (!url) return;
+  try {
+    const key = new URL(url).pathname.replace(/^\/+/, '');
+    if (key) await env.MEDIA.delete(key);
+  } catch {
+    // Ignore malformed URLs / delete failures — not worth blocking account deletion.
+  }
+}
 
 // We need to extend the Hono generic type to include the 'user' variable
 // that our middleware adds to the context.
@@ -84,6 +96,42 @@ users.put(
     }
   }
 );
+
+// DELETE /api/users/me - Permanently delete the current user's account.
+// Removes everything tied to the account: the saved voice conversation (KV),
+// uploaded media (R2), and the user row — which cascades to characters,
+// sessions, posts, friends, etc. via ON DELETE CASCADE in D1.
+users.delete('/me', authMiddleware, async (c) => {
+  const user = c.get('user');
+  const db = c.env.DB;
+
+  try {
+    // 1. Voice assistant data in KV (same key scheme as the voice routes).
+    await c.env.APP_CONFIG.delete(`voice:history:${user.id}`);
+
+    // 2. Uploaded media in R2 (current avatar / cover / shade avatar).
+    const media = await db
+      .prepare('SELECT avatar_url, cover_photo_url, shade_avatar_url FROM users WHERE id = ?')
+      .bind(user.id)
+      .first<{ avatar_url: string | null; cover_photo_url: string | null; shade_avatar_url: string | null }>();
+    if (media) {
+      await deleteMediaByUrl(c.env, media.avatar_url);
+      await deleteMediaByUrl(c.env, media.cover_photo_url);
+      await deleteMediaByUrl(c.env, media.shade_avatar_url);
+    }
+
+    // 3. The user row (cascades to all related D1 tables).
+    await db.prepare('DELETE FROM users WHERE id = ?').bind(user.id).run();
+
+    // 4. Clear the session cookie on the client.
+    deleteCookie(c, 'session_token');
+
+    return c.json({ message: 'Account deleted' });
+  } catch (error) {
+    console.error('Account deletion error:', error);
+    return c.json({ error: 'Failed to delete account' }, 500);
+  }
+});
 
 // GET /api/users/search - Search for users (for friend recommendations)
 users.get('/search', authMiddleware, async (c) => {

--- a/workers/src/api/voice.ts
+++ b/workers/src/api/voice.ts
@@ -6,6 +6,7 @@ import {
   chatRequestSchema,
   synthesizeRequestSchema,
   conversationRequestSchema,
+  voiceHistorySchema,
   type ChatMessage,
 } from '../shared/schemas/voice';
 
@@ -33,8 +34,17 @@ const voice = new Hono<App>();
 // Wit.ai API version
 const WIT_API_VERSION = '20230215';
 
-// System prompt for the voice assistant
-const VOICE_SYSTEM_PROMPT = `You are a helpful and friendly voice assistant. Keep your responses concise and conversational since they will be spoken aloud. Avoid using markdown, code blocks, or formatting that doesn't work well in speech. Respond naturally as if having a spoken conversation.`;
+// System prompt for the voice assistant. Personalized with the account's
+// username so the assistant knows who it's speaking with.
+function buildSystemPrompt(username?: string): string {
+  const base = `You are a helpful and friendly voice assistant for the .shade platform. Keep your responses concise and conversational since they will be spoken aloud. Avoid using markdown, code blocks, or formatting that doesn't work well in speech. Respond naturally as if having a spoken conversation.`;
+  return username ? `${base} You are speaking with ${username}; address them by name when it feels natural.` : base;
+}
+
+// Per-user KV key for the saved voice conversation.
+const voiceHistoryKey = (userId: string) => `voice:history:${userId}`;
+// Keep stored history bounded.
+const MAX_STORED_MESSAGES = 50;
 
 // Helper to convert ArrayBuffer to base64
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -135,10 +145,11 @@ voice.post(
   async (c) => {
     try {
       const { message, history } = c.req.valid('json');
+      const user = c.get('user');
 
       // Build messages array with system prompt
       const messages: ChatMessage[] = [
-        { role: 'system', content: VOICE_SYSTEM_PROMPT },
+        { role: 'system', content: buildSystemPrompt(user?.username) },
         ...history,
         { role: 'user', content: message },
       ];
@@ -231,7 +242,7 @@ voice.post('/conversation', authMiddleware, async (c) => {
 
     // Step 2: Generate AI response via Workers AI
     const messages: ChatMessage[] = [
-      { role: 'system', content: VOICE_SYSTEM_PROMPT },
+      { role: 'system', content: buildSystemPrompt(c.get('user')?.username) },
       ...history,
       { role: 'user', content: userText },
     ];
@@ -294,6 +305,46 @@ voice.get('/voices', authMiddleware, async (c) => {
   } catch (err: any) {
     console.error('Voices error:', err?.message || err);
     return c.json({ error: 'Failed to fetch voices' }, 500);
+  }
+});
+
+// GET /voice/history - Load the user's saved voice conversation (from KV)
+voice.get('/history', authMiddleware, async (c) => {
+  try {
+    const user = c.get('user');
+    const raw = await c.env.APP_CONFIG.get(voiceHistoryKey(user.id));
+    const messages = raw ? JSON.parse(raw) : [];
+    return c.json({ messages });
+  } catch (err: any) {
+    console.error('Load voice history error:', err?.message || err);
+    return c.json({ messages: [] });
+  }
+});
+
+// PUT /voice/history - Save the user's voice conversation (to KV)
+voice.put('/history', authMiddleware, zValidator('json', voiceHistorySchema), async (c) => {
+  try {
+    const user = c.get('user');
+    const { messages } = c.req.valid('json');
+    // Only keep the most recent messages so the KV value stays small.
+    const trimmed = messages.slice(-MAX_STORED_MESSAGES);
+    await c.env.APP_CONFIG.put(voiceHistoryKey(user.id), JSON.stringify(trimmed));
+    return c.json({ ok: true, count: trimmed.length });
+  } catch (err: any) {
+    console.error('Save voice history error:', err?.message || err);
+    return c.json({ error: 'Failed to save conversation' }, 500);
+  }
+});
+
+// DELETE /voice/history - Clear the user's saved voice conversation
+voice.delete('/history', authMiddleware, async (c) => {
+  try {
+    const user = c.get('user');
+    await c.env.APP_CONFIG.delete(voiceHistoryKey(user.id));
+    return c.json({ ok: true });
+  } catch (err: any) {
+    console.error('Clear voice history error:', err?.message || err);
+    return c.json({ error: 'Failed to clear conversation' }, 500);
   }
 });
 

--- a/workers/src/shared/schemas/voice.ts
+++ b/workers/src/shared/schemas/voice.ts
@@ -32,3 +32,10 @@ export const conversationRequestSchema = z.object({
 });
 
 export type ConversationRequest = z.infer<typeof conversationRequestSchema>;
+
+// Persisted voice conversation (per user, stored in KV).
+export const voiceHistorySchema = z.object({
+  messages: z.array(chatMessageSchema).max(200),
+});
+
+export type VoiceHistory = z.infer<typeof voiceHistorySchema>;


### PR DESCRIPTION
Implements per-user voice assistant data with KV storage, deleted when the account is deleted.

## Voice assistant data (KV)
- Each user's voice conversation is saved to KV (`APP_CONFIG`) under `voice:history:<userId>`, capped to the last 50 messages.
- New endpoints: `GET` / `PUT` / `DELETE /api/voice/history`.
- The assistant restores prior context on load, so it remembers earlier exchanges across sessions.
- The system prompt is personalized with the account's username ("You are speaking with `<username>`") in `/voice/chat` and `/voice/conversation`.
- Frontend (`VoiceAssistantContext`): loads history when authenticated, saves after each exchange, and clears the KV copy when the conversation is cleared.

## Account deletion (data lifecycle)
- New **`DELETE /api/users/me`** removes, in order: the KV voice history, the user's R2 media (avatar / cover / shade avatar), then the user row — which cascades to characters, sessions, posts, friends, etc. via `ON DELETE CASCADE`.
- **Settings → Delete Account** danger zone (type `DELETE` to confirm) calls it, logs out, and returns home.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅ (0 errors)
- Post-deploy: save/load history round-trip, personalized reply, and full account-delete on a throwaway account (login fails + KV key gone afterward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)