### PR TITLE
Fix storm8 attacks 500ing (Postgres DISTINCT ON in SQLite)

### DIFF
--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -387,26 +387,26 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
 
   const usableClanMembers = calculateUsableClanMembers(char.level, clanCount?.total || 0);
 
-  // Get top 3 attack abilities (one per category)
+  // Best attack ability per category (SQLite has no DISTINCT ON — use GROUP BY).
   const attackAbilities = await db
     .prepare(`
-      SELECT DISTINCT ON (a.category) a.attack_value
+      SELECT MAX(a.attack_value) AS attack_value
       FROM character_abilities ca
       JOIN abilities a ON ca.ability_id = a.id
       WHERE ca.character_id = ?
-      ORDER BY a.category, a.attack_value DESC
+      GROUP BY a.category
     `)
     .bind(characterId)
     .all();
 
-  // Get top 3 defense abilities (one per category)
+  // Best defense ability per category.
   const defenseAbilities = await db
     .prepare(`
-      SELECT DISTINCT ON (a.category) a.defense_value
+      SELECT MAX(a.defense_value) AS defense_value
       FROM character_abilities ca
       JOIN abilities a ON ca.ability_id = a.id
       WHERE ca.character_id = ?
-      ORDER BY a.category, a.defense_value DESC
+      GROUP BY a.category
     `)
     .bind(characterId)
     .all();


### PR DESCRIPTION
## Problem
**Every** storm8 attack returned `500 Internal Server Error`, so no battle ever completed — which is the real reason characters showed no wins, no deaths, and no kill/death trophies.

`getCharacterBattleStats()` (called for both attacker and defender on every attack) ran:
```sql
SELECT DISTINCT ON (a.category) a.attack_value ...
```
`DISTINCT ON` is **PostgreSQL-only**; SQLite/D1 rejects it, so the query threw on every call.

## Fix
Use the SQLite equivalent — best ability value per category via `GROUP BY`:
```sql
SELECT MAX(a.attack_value) AS attack_value
FROM character_abilities ca JOIN abilities a ON ca.ability_id = a.id
WHERE ca.character_id = ? GROUP BY a.category
```
(same for defense), then summed across categories — equivalent to the original intent.

## Notes
- Companion to #22 (trophy upserts + backfill, removed instant respawn, unattackable-at-0-HP). With this fix battles actually resolve, so those changes now take effect.
- `npm run build` ✅ • `npm run typecheck` ✅ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)