### PR TITLE
Use character ATK/DEF/SPD in storm8 battles

### DIFF
--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -456,7 +456,9 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
             />
             <div className="flex flex-col items-center justify-center px-2">
               <span className="text-2xl neon-text-strong">⚔️</span>
-              <span className="text-shade-red-500 font-bold text-lg">-{battle.damage_dealt}</span>
+              <span className={`font-bold text-lg ${battle.result?.critical ? 'text-yellow-400' : 'text-shade-red-500'}`}>-{battle.damage_dealt}</span>
+              {battle.result?.critical && <span className="text-[10px] font-bold text-yellow-400">CRIT! ×1.5</span>}
+              {battle.result?.dodged && <span className="text-[10px] font-bold text-blue-400">GLANCING ×0.5</span>}
             </div>
             <Combatant
               role="Defender"

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -357,6 +357,7 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
     .prepare(`
       SELECT
         c.id, c.level,
+        c.atk, c.def, c.spd,
         c.attack_skill_points, c.defense_skill_points, c.health_skill_points,
         c.current_health, c.max_health, c.current_stamina,
         c.unbanked_currency, c.banked_currency
@@ -367,6 +368,9 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
     .first<{
       id: string;
       level: number;
+      atk: number;
+      def: number;
+      spd: number;
       attack_skill_points: number;
       defense_skill_points: number;
       health_skill_points: number;
@@ -417,6 +421,9 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
   return {
     id: char.id,
     level: char.level,
+    attack: char.atk || 0,
+    defense: char.def || 0,
+    speed: char.spd || 0,
     attack_skill_points: char.attack_skill_points,
     defense_skill_points: char.defense_skill_points,
     health_skill_points: char.health_skill_points,

--- a/workers/src/core/storm8-battle-engine.ts
+++ b/workers/src/core/storm8-battle-engine.ts
@@ -15,6 +15,11 @@ export type CharacterBattleStats = {
   id: string;
   level: number;
 
+  // Core character stats (from the character sheet: atk / def / spd).
+  attack: number;
+  defense: number;
+  speed: number;
+
   // Skill points (scaling multiplier)
   attack_skill_points: number;
   defense_skill_points: number;
@@ -43,6 +48,8 @@ export type BattleResult = {
   currency_stolen: number;
   defender_health_after: number;
   defender_killed: boolean;
+  critical: boolean; // Attacker's speed landed a critical hit (1.5x)
+  dodged: boolean;   // Defender's speed glanced the blow (0.5x)
   variance_applied: number; // For debugging/display
   attacker_effective_power: number;
   defender_effective_power: number;
@@ -67,7 +74,8 @@ const DEFAULT_CONFIG: BattleConfig = {
 export function calculateAttackPower(stats: CharacterBattleStats): number {
   const equipmentPower = stats.equipment_attack * stats.usable_clan_members;
   const skillPower = stats.attack_skill_points * stats.level;
-  return equipmentPower + skillPower;
+  // The character's ATK stat contributes directly to attack power.
+  return equipmentPower + skillPower + (stats.attack || 0);
 }
 
 /**
@@ -77,7 +85,8 @@ export function calculateAttackPower(stats: CharacterBattleStats): number {
 export function calculateDefensePower(stats: CharacterBattleStats): number {
   const equipmentPower = stats.equipment_defense * stats.usable_clan_members;
   const skillPower = stats.defense_skill_points * stats.level;
-  return equipmentPower + skillPower;
+  // The character's DEF stat contributes directly to defense power.
+  return equipmentPower + skillPower + (stats.defense || 0);
 }
 
 /**
@@ -226,7 +235,7 @@ export function resolveBattle(
 
   // Determine outcome (probabilistic comparison)
   const powerDifferential = attackerWithVariance.value - defenderWithVariance.value;
-  const damageDealt = Math.max(0, Math.floor(powerDifferential));
+  let damageDealt = Math.max(0, Math.floor(powerDifferential));
 
   // Check if defender is protected (only for normal battles)
   const defenderProtected = !isHitlistBattle &&
@@ -241,10 +250,35 @@ export function resolveBattle(
       currency_stolen: 0,
       defender_health_after: defender.current_health,
       defender_killed: false,
+      critical: false,
+      dodged: false,
       variance_applied: attackerWithVariance.variance,
       attacker_effective_power: attackerWithVariance.value,
       defender_effective_power: defenderWithVariance.value,
     };
+  }
+
+  // Speed decides initiative: a faster attacker can land a critical hit (1.5x),
+  // a faster defender can partly dodge (0.5x). Bigger speed gaps = better odds.
+  let critical = false;
+  let dodged = false;
+  if (damageDealt > 0) {
+    const atkSpd = attacker.speed || 0;
+    const defSpd = defender.speed || 0;
+    const denom = atkSpd + defSpd + 1;
+    if (atkSpd > defSpd) {
+      const critChance = Math.min(0.5, (atkSpd - defSpd) / denom);
+      if (random() < critChance) {
+        damageDealt = Math.floor(damageDealt * 1.5);
+        critical = true;
+      }
+    } else if (defSpd > atkSpd) {
+      const dodgeChance = Math.min(0.5, (defSpd - atkSpd) / denom);
+      if (random() < dodgeChance) {
+        damageDealt = Math.floor(damageDealt * 0.5);
+        dodged = true;
+      }
+    }
   }
 
   // Apply damage
@@ -263,6 +297,8 @@ export function resolveBattle(
     currency_stolen: currencyStolen,
     defender_health_after: defenderHealthAfter,
     defender_killed: defenderKilled,
+    critical,
+    dodged,
     variance_applied: attackerWithVariance.variance,
     attacker_effective_power: attackerWithVariance.value,
     defender_effective_power: defenderWithVariance.value,


### PR DESCRIPTION
Folds the character sheet's **ATK / DEF / SPD** into storm8 combat (chosen direction).

## Changes
- **Attack power** now includes the character's `atk`; **defense power** includes `def` — added on top of `skill_points × level + equipment × clan`. So the stats you allocate on the dashboard now actually drive battles.
- **Speed matters** (was previously unused anywhere): faster attacker → chance at a **critical hit (1.5×)**; faster defender → chance to **glance/dodge (0.5×)**. Odds scale with the speed gap, capped at 50%. `BattleResult` now carries `critical` / `dodged`.
- `getCharacterBattleStats` reads `c.atk/c.def/c.spd`; the battle visual shows **CRIT!** / **GLANCING** badges.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Post-deploy: confirm damage now reflects ATK vs DEF (non-zero even with 0 skill points) and that crit/dodge fields are returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)