### PR TITLE
Speed initiative duels, dragon class damage, HP x100 per point

### DIFF
--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -316,6 +316,7 @@ function AllocatePointsForm({
       <h3 className="text-lg font-bold neon-text">
         You have {character.unspent_stat_points - totalAllocated} unspent stat points!
       </h3>
+      <p className="text-xs text-shade-red-400 mt-1">Each point in HP adds +100 HP. Other stats add +1 per point.</p>
       <form onSubmit={handleSubmit} className="space-y-2 mt-2">
         {Object.keys(points).map((stat) => (
           <div key={stat} className="flex items-center justify-between">

--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -385,19 +385,23 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
   const [attacking, setAttacking] = useState(false);
   const [battle, setBattle] = useState<any>(null);
   const [defHp, setDefHp] = useState(0);
+  const [atkHp, setAtkHp] = useState(0);
   const rafRef = useRef<number | null>(null);
 
-  // Animate the defender's HP from before -> after when a battle resolves.
-  const animateDamage = (before: number, after: number) => {
+  // Animate both combatants' HP from before -> after when a battle resolves.
+  const animateExchange = (d: any) => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    setDefHp(d.defender.health_before);
+    setAtkHp(d.attacker.health_before);
     const start = performance.now();
     const duration = 700;
+    const lerp = (a: number, b: number, k: number) => Math.round(a + (b - a) * k);
     const tick = (now: number) => {
       const k = Math.min(1, (now - start) / duration);
-      setDefHp(Math.round(before + (after - before) * k));
+      setDefHp(lerp(d.defender.health_before, d.defender.health_after, k));
+      setAtkHp(lerp(d.attacker.health_before, d.attacker.health_after, k));
       if (k < 1) rafRef.current = requestAnimationFrame(tick);
     };
-    setDefHp(before);
     rafRef.current = requestAnimationFrame(tick);
   };
 
@@ -414,7 +418,7 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
       const res = await apiClient.post<{ data: any }>('/storm8/attack', { defender_character_id: targetId.trim() });
       const d = res.data;
       setBattle(d);
-      animateDamage(d.defender.health_before, d.defender.health_after);
+      animateExchange(d);
       onUpdate();
     } catch (err: any) {
       setError(err.message || 'Attack failed');
@@ -446,22 +450,29 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
       {/* Battle arena */}
       {battle && (
         <div className="bg-shade-black-700 neon-border rounded-lg p-4 mb-4">
+          <p className="text-center text-[11px] uppercase tracking-widest text-shade-red-400 mb-2">
+            {battle.first_striker === 'defender'
+              ? `${battle.defender.gamertag} was faster — struck first!`
+              : `${battle.attacker.gamertag} was faster — struck first!`}
+          </p>
           <div className="flex items-stretch gap-3">
             <Combatant
-              role="Attacker"
+              role={`Attacker${battle.first_striker === 'attacker' ? ' ⚡' : ''}`}
               name={battle.attacker.gamertag}
               avatar={user?.shade_avatar_url}
-              hp={battle.attacker.health}
+              hp={atkHp}
               maxHp={battle.attacker.max_health}
+              defeated={battle.attacker.killed && atkHp <= 0}
             />
             <div className="flex flex-col items-center justify-center px-2">
               <span className="text-2xl neon-text-strong">⚔️</span>
-              <span className={`font-bold text-lg ${battle.result?.critical ? 'text-yellow-400' : 'text-shade-red-500'}`}>-{battle.damage_dealt}</span>
-              {battle.result?.critical && <span className="text-[10px] font-bold text-yellow-400">CRIT! ×1.5</span>}
-              {battle.result?.dodged && <span className="text-[10px] font-bold text-blue-400">GLANCING ×0.5</span>}
+              <span className="font-bold text-shade-red-500">-{battle.damage_dealt}</span>
+              {battle.damage_to_attacker > 0 && (
+                <span className="text-[10px] text-blue-300 mt-1">counter -{battle.damage_to_attacker}</span>
+              )}
             </div>
             <Combatant
-              role="Defender"
+              role={`Defender${battle.first_striker === 'defender' ? ' ⚡' : ''}`}
               name={battle.defender.gamertag}
               hp={defHp}
               maxHp={battle.defender.max_health}
@@ -471,9 +482,11 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
           <div className="text-center mt-3 text-sm">
             {battle.defender.killed
               ? <p className="text-shade-red-600 font-bold animate-pulse">💀 {battle.defender.gamertag} was DEFEATED!</p>
-              : battle.result?.attacker_won
-                ? <p className="text-green-500">Hit for {battle.damage_dealt} damage.</p>
-                : <p className="text-shade-red-300">Attack deflected — no damage.</p>}
+              : battle.attacker.killed
+                ? <p className="text-shade-red-600 font-bold animate-pulse">💀 You were DEFEATED by {battle.defender.gamertag}'s counterattack!</p>
+                : battle.result?.attacker_won
+                  ? <p className="text-green-500">You won the exchange — {battle.damage_dealt} dealt vs {battle.damage_to_attacker} taken.</p>
+                  : <p className="text-shade-red-300">You lost the exchange — {battle.damage_dealt} dealt vs {battle.damage_to_attacker} taken.</p>}
             <p className="text-shade-red-400 mt-1">
               {battle.currency_stolen > 0 && <span>💰 Stole {battle.currency_stolen} • </span>}
               +{battle.xp_gained} XP

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -506,6 +506,9 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
         return c.json({ error: 'Invalid number of points to allocate.' }, 400);
     }
 
+    // Each point spent on HP is worth +100 HP; the other stats are +1 per point.
+    // unspent_stat_points still decreases by the number of points spent.
+    const HP_PER_POINT = 100;
     await db.prepare(`
         UPDATE characters
         SET
@@ -517,7 +520,7 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
             unspent_stat_points = unspent_stat_points - ?
         WHERE id = ?
     `).bind(
-        pointsToAllocate.hp,
+        pointsToAllocate.hp * HP_PER_POINT,
         pointsToAllocate.atk,
         pointsToAllocate.def,
         pointsToAllocate.mp,

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -356,7 +356,7 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
   const char = await db
     .prepare(`
       SELECT
-        c.id, c.level,
+        c.id, c.level, c.class,
         c.atk, c.def, c.spd,
         c.attack_skill_points, c.defense_skill_points, c.health_skill_points,
         c.current_health, c.max_health, c.current_stamina,
@@ -368,6 +368,7 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
     .first<{
       id: string;
       level: number;
+      class: string;
       atk: number;
       def: number;
       spd: number;
@@ -421,6 +422,7 @@ async function getCharacterBattleStats(db: D1Database, characterId: string): Pro
   return {
     id: char.id,
     level: char.level,
+    char_class: char.class,
     attack: char.atk || 0,
     defense: char.def || 0,
     speed: char.spd || 0,
@@ -562,6 +564,10 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
     db.prepare('UPDATE characters SET current_health = ? WHERE id = ?')
       .bind(result.defender_health_after, defenderStats.id),
 
+    // Update attacker health (they can take counterattack damage)
+    db.prepare('UPDATE characters SET current_health = ? WHERE id = ?')
+      .bind(result.attacker_health_after, attackerStats.id),
+
     // Create battle record
     db.prepare(`
       INSERT INTO battles (id, attacker_char_id, defender_char_id, mode, state, seed, battle_type, started_at, ended_at, winner_char_id, currency_stolen, defender_health_after)
@@ -607,13 +613,18 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
     );
   }
 
-  // Update trophies and handle kill. On a kill the defender stays at 0 health
-  // (set above) — they are "defeated" and unattackable until they heal at the
-  // hospital, rather than instantly respawning.
+  // Update trophies and handle kills. A defeated character stays at 0 health
+  // (set above) — unattackable until they heal — rather than respawning. The
+  // attacker can also die to the defender's counterattack.
   if (result.defender_killed) {
     statements.push(
       bumpTrophies(db, attackerStats.id, { kills: 1, wins: 1 }),
       bumpTrophies(db, defenderStats.id, { deaths: 1, losses: 1 })
+    );
+  } else if (result.attacker_killed) {
+    statements.push(
+      bumpTrophies(db, defenderStats.id, { kills: 1, wins: 1 }),
+      bumpTrophies(db, attackerStats.id, { deaths: 1, losses: 1 })
     );
   } else {
     statements.push(
@@ -643,12 +654,14 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
     data: {
       battle_id: battleId,
       result,
-      // Combatant snapshots so the client can render HP bars and the damage hit.
+      // Combatant snapshots so the client can render HP bars and the exchange.
       attacker: {
         id: attackerStats.id,
         gamertag: nameOf(attackerStats.id),
-        health: attackerStats.current_health,
+        health_before: attackerStats.current_health,
+        health_after: result.attacker_health_after,
         max_health: attackerStats.max_health,
+        killed: result.attacker_killed,
       },
       defender: {
         id: defenderStats.id,
@@ -658,7 +671,9 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
         max_health: defenderStats.max_health,
         killed: result.defender_killed,
       },
+      first_striker: result.first_striker,
       damage_dealt: result.damage_dealt,
+      damage_to_attacker: result.damage_to_attacker,
       currency_stolen: result.currency_stolen,
       xp_gained: xpGained,
       xp_multiplier: xpMultiplier,
@@ -802,9 +817,9 @@ storm8.post('/hitlist/attack', zValidator('json', attackHitlistSchema), async (c
     return c.json({ error: 'Insufficient stamina' }, 400);
   }
 
-  // Resolve battle (hitlist = true, no health protection)
+  // Resolve battle (hitlist = ambush: no health protection, no counterattack)
   const seed = crypto.randomUUID();
-  const result = resolveBattle(attackerStats, defenderStats, seed, {}, true);
+  const result = resolveBattle(attackerStats, defenderStats, seed, {}, true, false);
 
   const now = new Date().toISOString();
   const statements = [

--- a/workers/src/core/storm8-battle-engine.ts
+++ b/workers/src/core/storm8-battle-engine.ts
@@ -14,6 +14,7 @@
 export type CharacterBattleStats = {
   id: string;
   level: number;
+  char_class: string; // phoenix | dphoenix | dragon | ddragon | kies
 
   // Core character stats (from the character sheet: atk / def / spd).
   attack: number;
@@ -44,12 +45,14 @@ export type CharacterBattleStats = {
 
 export type BattleResult = {
   attacker_won: boolean;
-  damage_dealt: number;
+  damage_dealt: number;          // Damage the attacker dealt to the defender
+  damage_to_attacker: number;    // Counterattack damage the defender dealt back
   currency_stolen: number;
   defender_health_after: number;
+  attacker_health_after: number;
   defender_killed: boolean;
-  critical: boolean; // Attacker's speed landed a critical hit (1.5x)
-  dodged: boolean;   // Defender's speed glanced the blow (0.5x)
+  attacker_killed: boolean;      // The attacker can die to the counterattack
+  first_striker: 'attacker' | 'defender'; // Decided by speed (initiative)
   variance_applied: number; // For debugging/display
   attacker_effective_power: number;
   defender_effective_power: number;
@@ -71,11 +74,21 @@ const DEFAULT_CONFIG: BattleConfig = {
  * Calculate total attack power using Storm8 formula:
  * Total Attack = (equipment_attack × usable_clan_members) + (attack_skill_points × level)
  */
+// Dragon classes are bruisers: they convert their defensive/mobility stats into
+// offense, so their damage scales off DEF + SPD on top of raw ATK.
+function classAttackBonus(stats: CharacterBattleStats): number {
+  if (stats.char_class === 'dragon' || stats.char_class === 'ddragon') {
+    return (stats.defense || 0) + (stats.speed || 0);
+  }
+  return 0;
+}
+
 export function calculateAttackPower(stats: CharacterBattleStats): number {
   const equipmentPower = stats.equipment_attack * stats.usable_clan_members;
   const skillPower = stats.attack_skill_points * stats.level;
-  // The character's ATK stat contributes directly to attack power.
-  return equipmentPower + skillPower + (stats.attack || 0);
+  // The character's ATK stat contributes directly to attack power, plus any
+  // class-specific bonus (dragons gain from DEF + SPD).
+  return equipmentPower + skillPower + (stats.attack || 0) + classAttackBonus(stats);
 }
 
 /**
@@ -206,13 +219,19 @@ function calculateCurrencyStolen(
 }
 
 /**
- * Main battle resolution function
+ * Main battle resolution function.
+ *
+ * Speed decides initiative: the faster combatant strikes first. If the first
+ * strike is lethal, the slower one dies before they can hit back. Otherwise the
+ * other side lands a counterattack — so a faster, harder-hitting opponent can
+ * kill you when you attack them.
  *
  * @param attacker - Attacker's battle stats
  * @param defender - Defender's battle stats
  * @param seed - Random seed for deterministic results
  * @param config - Battle configuration (optional)
  * @param isHitlistBattle - If true, ignores health protection threshold
+ * @param allowCounter - If false, the defender does not strike back (ambush/hitlist)
  * @returns Battle result
  */
 export function resolveBattle(
@@ -220,88 +239,91 @@ export function resolveBattle(
   defender: CharacterBattleStats,
   seed: string,
   config: Partial<BattleConfig> = {},
-  isHitlistBattle: boolean = false
+  isHitlistBattle: boolean = false,
+  allowCounter: boolean = true
 ): BattleResult {
   const finalConfig = { ...DEFAULT_CONFIG, ...config };
   const random = seededRandom(seed);
 
-  // Calculate base powers
-  const attackerBasePower = calculateAttackPower(attacker);
-  const defenderBasePower = calculateDefensePower(defender);
+  // Each side's effective powers (with variance).
+  const attackerAtk = applyVariance(calculateAttackPower(attacker), finalConfig.variance_percentage, random);
+  const defenderDef = applyVariance(calculateDefensePower(defender), finalConfig.variance_percentage, random);
+  const defenderAtk = applyVariance(calculateAttackPower(defender), finalConfig.variance_percentage, random);
+  const attackerDef = applyVariance(calculateDefensePower(attacker), finalConfig.variance_percentage, random);
 
-  // Apply variance (Storm8's "luck factor")
-  const attackerWithVariance = applyVariance(attackerBasePower, finalConfig.variance_percentage, random);
-  const defenderWithVariance = applyVariance(defenderBasePower, finalConfig.variance_percentage, random);
+  // Potential damage each would deal to the other.
+  const attackerHit = Math.max(0, Math.floor(attackerAtk.value - defenderDef.value));
+  const counterHit = allowCounter ? Math.max(0, Math.floor(defenderAtk.value - attackerDef.value)) : 0;
 
-  // Determine outcome (probabilistic comparison)
-  const powerDifferential = attackerWithVariance.value - defenderWithVariance.value;
-  let damageDealt = Math.max(0, Math.floor(powerDifferential));
+  const baseResult = {
+    variance_applied: attackerAtk.variance,
+    attacker_effective_power: attackerAtk.value,
+    defender_effective_power: defenderDef.value,
+  };
 
-  // Check if defender is protected (only for normal battles)
+  // Defender protection (normal battles only): low-health defenders escape.
   const defenderProtected = !isHitlistBattle &&
                            defender.current_health <= finalConfig.health_protection_threshold &&
                            defender.current_health > 0;
 
   if (defenderProtected) {
-    // Defender escaped to safety
     return {
       attacker_won: false,
       damage_dealt: 0,
+      damage_to_attacker: 0,
       currency_stolen: 0,
       defender_health_after: defender.current_health,
+      attacker_health_after: attacker.current_health,
       defender_killed: false,
-      critical: false,
-      dodged: false,
-      variance_applied: attackerWithVariance.variance,
-      attacker_effective_power: attackerWithVariance.value,
-      defender_effective_power: defenderWithVariance.value,
+      attacker_killed: false,
+      first_striker: 'attacker',
+      ...baseResult,
     };
   }
 
-  // Speed decides initiative: a faster attacker can land a critical hit (1.5x),
-  // a faster defender can partly dodge (0.5x). Bigger speed gaps = better odds.
-  let critical = false;
-  let dodged = false;
-  if (damageDealt > 0) {
-    const atkSpd = attacker.speed || 0;
-    const defSpd = defender.speed || 0;
-    const denom = atkSpd + defSpd + 1;
-    if (atkSpd > defSpd) {
-      const critChance = Math.min(0.5, (atkSpd - defSpd) / denom);
-      if (random() < critChance) {
-        damageDealt = Math.floor(damageDealt * 1.5);
-        critical = true;
-      }
-    } else if (defSpd > atkSpd) {
-      const dodgeChance = Math.min(0.5, (defSpd - atkSpd) / denom);
-      if (random() < dodgeChance) {
-        damageDealt = Math.floor(damageDealt * 0.5);
-        dodged = true;
-      }
+  // Initiative by speed; the attacker wins ties since they initiated.
+  const attackerFirst = (attacker.speed || 0) >= (defender.speed || 0);
+
+  let attackerHealthAfter = attacker.current_health;
+  let defenderHealthAfter = defender.current_health;
+  let attackerKilled = false;
+  let defenderKilled = false;
+
+  if (attackerFirst) {
+    defenderHealthAfter = Math.max(0, defender.current_health - attackerHit);
+    defenderKilled = defenderHealthAfter === 0;
+    if (!defenderKilled) {
+      attackerHealthAfter = Math.max(0, attacker.current_health - counterHit);
+      attackerKilled = attackerHealthAfter === 0;
+    }
+  } else {
+    // Faster defender lands a pre-emptive counter first.
+    attackerHealthAfter = Math.max(0, attacker.current_health - counterHit);
+    attackerKilled = attackerHealthAfter === 0;
+    if (!attackerKilled) {
+      defenderHealthAfter = Math.max(0, defender.current_health - attackerHit);
+      defenderKilled = defenderHealthAfter === 0;
     }
   }
 
-  // Apply damage
-  const defenderHealthAfter = Math.max(0, defender.current_health - damageDealt);
-  const defenderKilled = defenderHealthAfter === 0;
-  const attackerWon = damageDealt > 0;
+  // The attacker wins if they kill the defender, or (both survive) out-damage them.
+  const attackerWon = defenderKilled || (!attackerKilled && attackerHit > counterHit);
 
-  // Calculate currency stolen (only if attacker won)
-  const currencyStolen = attackerWon
-    ? calculateCurrencyStolen(damageDealt, defender.unbanked_currency, finalConfig.currency_steal_percentage)
+  const currencyStolen = (defenderKilled || (attackerWon && attackerHit > 0))
+    ? calculateCurrencyStolen(attackerHit, defender.unbanked_currency, finalConfig.currency_steal_percentage)
     : 0;
 
   return {
     attacker_won: attackerWon,
-    damage_dealt: damageDealt,
+    damage_dealt: attackerHit,
+    damage_to_attacker: counterHit,
     currency_stolen: currencyStolen,
     defender_health_after: defenderHealthAfter,
+    attacker_health_after: attackerHealthAfter,
     defender_killed: defenderKilled,
-    critical,
-    dodged,
-    variance_applied: attackerWithVariance.variance,
-    attacker_effective_power: attackerWithVariance.value,
-    defender_effective_power: defenderWithVariance.value,
+    attacker_killed: attackerKilled,
+    first_striker: attackerFirst ? 'attacker' : 'defender',
+    ...baseResult,
   };
 }
 


### PR DESCRIPTION
Implements the requested combat/stat changes.

## Speed decides who strikes first
`resolveBattle` is now a **duel**: the faster combatant strikes first. A lethal first strike stops the counter; otherwise the other side **counterattacks** — so attacking a faster, harder-hitting target can get **you** killed. New result fields: `attacker_health_after`, `attacker_killed`, `damage_to_attacker`, `first_striker`. `/attack` updates both healths and gives the kill/death to whichever side falls. The hitlist remains one-sided (ambush — no counter).

## Dragons scale off DEF + SPD
`dragon` / `ddragon` classes add **DEF + SPD** to their attack power (on top of ATK), so they hit hard while built tanky/fast. (Picked DEF+SPD over DEF+HP since HP is now huge — see below; easy to switch.)

## HP x100 per point
`/game` stat allocation: each point in **HP now adds +100 HP** (other stats +1). Dashboard notes it.

## Visual
The arena animates **both** HP bars, shows **who struck first (⚡)**, the counterattack damage, and an attacker/defender **DEFEATED** state.

## Also
- Cleared the 3 pending battles from the DB.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)