### PR TITLE
Unify battle HP with HP stat; mitigation damage (HP visibly drops)

### DIFF
--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -103,6 +103,11 @@ function SkillAllocation({ character, onUpdate }: { character: any; onUpdate: ()
   return (
     <div className="beveled-panel rounded-lg p-6 mb-6">
       <h2 className="text-2xl font-bold mb-4 neon-text">Skill Allocation</h2>
+      <p className="text-xs text-shade-red-300 mb-3 bg-shade-black-800 p-2 rounded neon-border">
+        Optional <span className="text-shade-red-100">bonus</span> points. Battles are driven mainly by your
+        character's <span className="text-shade-red-100">ATK / DEF / SPD / HP</span> (allocate those on the
+        Dashboard); these skill points add extra attack/defense/HP on top.
+      </p>
       <p className="text-shade-red-200 mb-4">
         Available Points: <span className="text-shade-red-600 font-bold text-xl">{remaining}</span>
       </p>
@@ -372,6 +377,34 @@ function AbilityShop({ character, onUpdate }: { character: any; onUpdate: () => 
             ))
           )}
         </div>
+      )}
+    </div>
+  );
+}
+
+// Shows the stats that actually drive combat, so it's clear what matters.
+function BattleStats({ character }: { character: any }) {
+  const cur = character.current_health ?? 0;
+  const max = character.max_health ?? 1;
+  return (
+    <div className="beveled-panel rounded-lg p-6 mb-6">
+      <h2 className="text-2xl font-bold mb-2 neon-text">Your Battle Stats</h2>
+      <p className="text-xs text-shade-red-300 mb-3">These drive your damage and survivability. Allocate on the Dashboard.</p>
+      <div className="grid grid-cols-4 gap-2 text-center mb-3">
+        {[['ATK', character.atk], ['DEF', character.def], ['SPD', character.spd], ['Class', character.class]].map(([label, val]) => (
+          <div key={label as string} className="bg-shade-black-800 rounded p-2 neon-border">
+            <div className="text-[10px] uppercase text-shade-red-400">{label}</div>
+            <div className="text-shade-red-100 font-semibold truncate">{val ?? 0}</div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-between text-sm text-shade-red-200 mb-1">
+        <span>Health</span>
+        <span>{cur.toLocaleString()} / {max.toLocaleString()}</span>
+      </div>
+      <HpBar current={cur} max={max} />
+      {cur <= 0 && (
+        <p className="text-xs text-shade-red-600 mt-2">💀 Defeated — heal at the hospital to fight again.</p>
       )}
     </div>
   );
@@ -743,6 +776,7 @@ export default function Storm8Page() {
 
         {/* Right Column */}
         <div>
+          <BattleStats character={character} />
           <AttackInterface character={character} onUpdate={fetchCharacter} />
           <HitlistBrowser character={character} onUpdate={fetchCharacter} />
           <BattleFeed />

--- a/migrations/0012_unify_battle_health.sql
+++ b/migrations/0012_unify_battle_health.sql
@@ -1,0 +1,8 @@
+-- Unify the battle health pool with the character's HP stat.
+--
+-- max_health was hardcoded ~100 while the hp stat is in the thousands, so
+-- attacks either did nothing (defense > attack) or one-shot the tiny pool —
+-- you could never watch health tick down. Seed the battle pool from hp so
+-- damage chips it gradually and the HP you allocate actually matters.
+
+UPDATE characters SET max_health = MAX(hp, 100), current_health = MAX(hp, 100);

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -507,8 +507,10 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
     }
 
     // Each point spent on HP is worth +100 HP; the other stats are +1 per point.
-    // unspent_stat_points still decreases by the number of points spent.
+    // unspent_stat_points still decreases by the number of points spent. The HP
+    // stat IS the battle health pool, so grow max/current health alongside it.
     const HP_PER_POINT = 100;
+    const hpGain = pointsToAllocate.hp * HP_PER_POINT;
     await db.prepare(`
         UPDATE characters
         SET
@@ -517,14 +519,18 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
             def = def + ?,
             mp = mp + ?,
             spd = spd + ?,
+            max_health = max_health + ?,
+            current_health = current_health + ?,
             unspent_stat_points = unspent_stat_points - ?
         WHERE id = ?
     `).bind(
-        pointsToAllocate.hp * HP_PER_POINT,
+        hpGain,
         pointsToAllocate.atk,
         pointsToAllocate.def,
         pointsToAllocate.mp,
         pointsToAllocate.spd,
+        hpGain,
+        hpGain,
         totalPointsToSpend,
         character.id
     ).run();

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -89,7 +89,8 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
         energy_skill_points = energy_skill_points + ?,
         stamina_skill_points = stamina_skill_points + ?,
         unspent_stat_points = unspent_stat_points - ?,
-        max_health = 100 + ((health_skill_points + ?) * 10),
+        max_health = max_health + (? * 10),
+        current_health = current_health + (? * 10),
         max_energy = 20 + (energy_skill_points + ?),
         max_stamina = 5 + (stamina_skill_points + ?)
       WHERE user_id = ?
@@ -101,6 +102,7 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
       allocation.energy,
       allocation.stamina,
       totalAllocated,
+      allocation.health,
       allocation.health,
       allocation.energy,
       allocation.stamina,

--- a/workers/src/core/storm8-battle-engine.ts
+++ b/workers/src/core/storm8-battle-engine.ts
@@ -66,9 +66,17 @@ export type BattleConfig = {
 
 const DEFAULT_CONFIG: BattleConfig = {
   variance_percentage: 15,
-  health_protection_threshold: 26,
+  // No low-health "escape" — every hit lands so health visibly ticks down to 0.
+  health_protection_threshold: 0,
   currency_steal_percentage: 10,
 };
+
+// Damage with mitigation: defense reduces damage but never blocks it entirely,
+// so a landed attack always chips at least some health (you can see HP drop).
+function computeHit(attackValue: number, defenseValue: number): number {
+  if (attackValue <= 0) return 0;
+  return Math.max(1, Math.round((attackValue * attackValue) / (attackValue + defenseValue + 1)));
+}
 
 /**
  * Calculate total attack power using Storm8 formula:
@@ -251,9 +259,9 @@ export function resolveBattle(
   const defenderAtk = applyVariance(calculateAttackPower(defender), finalConfig.variance_percentage, random);
   const attackerDef = applyVariance(calculateDefensePower(attacker), finalConfig.variance_percentage, random);
 
-  // Potential damage each would deal to the other.
-  const attackerHit = Math.max(0, Math.floor(attackerAtk.value - defenderDef.value));
-  const counterHit = allowCounter ? Math.max(0, Math.floor(defenderAtk.value - attackerDef.value)) : 0;
+  // Potential damage each would deal to the other (mitigation, never 0 if you hit).
+  const attackerHit = computeHit(attackerAtk.value, defenderDef.value);
+  const counterHit = allowCounter ? computeHit(defenderAtk.value, attackerDef.value) : 0;
 
   const baseResult = {
     variance_applied: attackerAtk.variance,


### PR DESCRIPTION
Fixes "can't see hit points go down each attack" and the stat-system confusion.

## Root cause
Battle `max_health` was hardcoded ~**100** while the `hp` stat was in the **thousands**, and damage was `atk − def` — which is **0** whenever defense ≥ attack (e.g. truest 1292 ATK vs Caspian 1850 DEF) or a **one-shot** of the tiny 100 pool. Either way you never saw health tick down.

## Fixes
- **Battle HP pool = the HP stat.** `/game` HP allocation now grows max/current health (+100 per point), storm8 health skill points **add** on top (instead of resetting the pool to 100), and **migration 0012** backfills `max_health`/`current_health` from `hp` (applied to remote; founder pools now 10,402 / 10,500).
- **Mitigation damage** (`atk²/(atk+def)`, min 1): every landed hit chips health instead of being fully blocked, so HP visibly drops each attack.
- Removed the low-health "escape" so health reaches 0 and kills land.
- **Storm8 page:** new **Battle Stats** panel (ATK/DEF/SPD/HP + health bar) and a note that skill points are optional bonuses — combat is driven by the character's ATK/DEF/SPD/HP from the Dashboard.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Migration 0012 applied to remote.
- Post-deploy: repeated attacks show health dropping each hit down to a kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)