### PR TITLE
Add character selector to the Battle tab

### DIFF
--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -2,6 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 import { apiClient } from '../lib/api';
 import { useAuth } from '../lib/AuthContext';
 
+// Append the acting character to a storm8 API path so the server acts on the
+// character selected in the Battle tab (not just slot 1).
+function withChar(path: string, characterId?: string | null) {
+  if (!characterId) return path;
+  return `${path}${path.includes('?') ? '&' : '?'}character_id=${encodeURIComponent(characterId)}`;
+}
+
 // A health bar that colors by remaining percentage.
 function HpBar({ current, max }: { current: number; max: number }) {
   const pct = max > 0 ? Math.max(0, Math.min(100, (current / max) * 100)) : 0;
@@ -71,7 +78,7 @@ function SkillAllocation({ character, onUpdate }: { character: any; onUpdate: ()
       return;
     }
     try {
-      await apiClient.post('/storm8/skills/allocate', skills);
+      await apiClient.post(withChar('/storm8/skills/allocate', character?.id), skills);
       setSkills({ attack: 0, defense: 0, health: 0, energy: 0, stamina: 0 });
       onUpdate();
     } catch (err: any) {
@@ -163,7 +170,7 @@ function SkillAllocation({ character, onUpdate }: { character: any; onUpdate: ()
 }
 
 // Clan Management UI
-function ClanManagement({ onUpdate }: { onUpdate: () => void }) {
+function ClanManagement({ characterId, onUpdate }: { characterId?: string | null; onUpdate: () => void }) {
   const [clanData, setClanData] = useState<any>(null);
   const [recruitCount, setRecruitCount] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -171,7 +178,7 @@ function ClanManagement({ onUpdate }: { onUpdate: () => void }) {
 
   const fetchClan = async () => {
     try {
-      const res = await apiClient.get<{ data: any }>('/storm8/clan');
+      const res = await apiClient.get<{ data: any }>(withChar('/storm8/clan', characterId));
       setClanData(res.data);
     } catch (err: any) {
       setError(err.message);
@@ -187,7 +194,7 @@ function ClanManagement({ onUpdate }: { onUpdate: () => void }) {
   const handleRecruit = async () => {
     setError(null);
     try {
-      await apiClient.post('/storm8/clan/recruit', { count: recruitCount });
+      await apiClient.post(withChar('/storm8/clan/recruit', characterId), { count: recruitCount });
       fetchClan();
       onUpdate();
     } catch (err: any) {
@@ -264,8 +271,8 @@ function AbilityShop({ character, onUpdate }: { character: any; onUpdate: () => 
   const fetchAbilities = async () => {
     try {
       const [shopRes, ownedRes] = await Promise.all([
-        apiClient.get<{ data: any[] }>('/storm8/abilities'),
-        apiClient.get<{ data: any[] }>('/storm8/abilities/owned'),
+        apiClient.get<{ data: any[] }>(withChar('/storm8/abilities', character?.id)),
+        apiClient.get<{ data: any[] }>(withChar('/storm8/abilities/owned', character?.id)),
       ]);
       setAbilities(shopRes.data || []);
       setOwnedAbilities(ownedRes.data || []);
@@ -283,7 +290,7 @@ function AbilityShop({ character, onUpdate }: { character: any; onUpdate: () => 
   const handlePurchase = async (abilityId: string) => {
     setError(null);
     try {
-      await apiClient.post('/storm8/abilities/purchase', { ability_id: abilityId });
+      await apiClient.post(withChar('/storm8/abilities/purchase', character?.id), { ability_id: abilityId });
       fetchAbilities();
       onUpdate();
     } catch (err: any) {
@@ -455,7 +462,7 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
     }
     setAttacking(true);
     try {
-      const res = await apiClient.post<{ data: any }>('/storm8/attack', { defender_character_id: targetId.trim() });
+      const res = await apiClient.post<{ data: any }>(withChar('/storm8/attack', character?.id), { defender_character_id: targetId.trim() });
       const d = res.data;
       setBattle(d);
       animateExchange(d);
@@ -603,7 +610,7 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
       return;
     }
     try {
-      await apiClient.post('/storm8/hitlist/post', {
+      await apiClient.post(withChar('/storm8/hitlist/post', character?.id), {
         target_character_id: postTarget,
         bounty_amount: bountyAmount,
       });
@@ -618,7 +625,7 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
   const handleHitlistAttack = async (hitlistId: string) => {
     setError(null);
     try {
-      const res = await apiClient.post<{ bounty_claimed?: boolean; bounty_amount?: number; damage_dealt?: number }>('/storm8/hitlist/attack', { hitlist_id: hitlistId });
+      const res = await apiClient.post<{ bounty_claimed?: boolean; bounty_amount?: number; damage_dealt?: number }>(withChar('/storm8/hitlist/attack', character?.id), { hitlist_id: hitlistId });
       alert(`Attack successful! ${res.bounty_claimed ? `You claimed the ${res.bounty_amount} bounty!` : `Dealt ${res.damage_dealt} damage`}`);
       fetchHitlist();
       onUpdate();
@@ -696,13 +703,13 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
 }
 
 // Battle Feed Display
-function BattleFeed() {
+function BattleFeed({ characterId }: { characterId?: string | null }) {
   const [feed, setFeed] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchFeed = async () => {
     try {
-      const res = await apiClient.get<{ data: any[] }>('/storm8/feed');
+      const res = await apiClient.get<{ data: any[] }>(withChar('/storm8/feed', characterId));
       setFeed(res.data || []);
     } catch (err) {
       console.error('Failed to fetch battle feed', err);
@@ -760,14 +767,17 @@ function BattleFeed() {
 
 // Main Storm8 Page
 export default function Storm8Page() {
-  const [character, setCharacter] = useState<any>(null);
+  const [characters, setCharacters] = useState<any[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchCharacter = async () => {
+  const fetchCharacters = async () => {
     try {
-      const res = await apiClient.get<{ data: any }>('/game/character');
-      setCharacter(res.data);
+      const res = await apiClient.get<{ data: any[] }>('/game/my-characters');
+      const list = (res.data || []).filter((ch) => ch.first_game_access_completed);
+      setCharacters(list);
+      setSelectedId((prev) => (prev && list.some((ch) => ch.id === prev) ? prev : list[0]?.id ?? null));
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -776,31 +786,51 @@ export default function Storm8Page() {
   };
 
   useEffect(() => {
-    fetchCharacter();
+    fetchCharacters();
   }, []);
+
+  const character = characters.find((ch) => ch.id === selectedId) ?? null;
 
   if (loading) return <div className="p-4 text-shade-red-200">Loading...</div>;
   if (error) return <div className="p-4 text-shade-red-600">Error: {error}</div>;
-  if (!character) return <div className="p-4 text-shade-red-300">No character found</div>;
+  if (!character) return <div className="p-4 text-shade-red-300">No character found. Create one on the Dashboard.</div>;
 
   return (
     <div className="p-4 max-w-6xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6 neon-text">Storm8 Battle System</h1>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+        <h1 className="text-3xl font-bold neon-text">Storm8 Battle System</h1>
+        {/* Character selector: choose which of your characters fights/builds */}
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-shade-red-300">Fighting as:</span>
+          <select
+            value={selectedId ?? ''}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="p-2 rounded bg-shade-black-600 neon-border text-shade-red-100"
+          >
+            {characters.map((ch) => (
+              <option key={ch.id} value={ch.id}>
+                {ch.gamertag} — Slot {ch.slot_number} (Lv.{ch.level} {ch.class})
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
 
-      <div className="grid md:grid-cols-2 gap-6">
+      {/* Keyed by selectedId so panels refetch when you switch characters */}
+      <div className="grid md:grid-cols-2 gap-6" key={selectedId}>
         {/* Left Column */}
         <div>
-          <SkillAllocation character={character} onUpdate={fetchCharacter} />
-          <ClanManagement onUpdate={fetchCharacter} />
-          <AbilityShop character={character} onUpdate={fetchCharacter} />
+          <SkillAllocation character={character} onUpdate={fetchCharacters} />
+          <ClanManagement characterId={character.id} onUpdate={fetchCharacters} />
+          <AbilityShop character={character} onUpdate={fetchCharacters} />
         </div>
 
         {/* Right Column */}
         <div>
           <BattleStats character={character} />
-          <AttackInterface character={character} onUpdate={fetchCharacter} />
-          <HitlistBrowser character={character} onUpdate={fetchCharacter} />
-          <BattleFeed />
+          <AttackInterface character={character} onUpdate={fetchCharacters} />
+          <HitlistBrowser character={character} onUpdate={fetchCharacters} />
+          <BattleFeed characterId={character.id} />
         </div>
       </div>
     </div>

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -46,6 +46,25 @@ const storm8 = new Hono<App>();
 // All routes require authentication
 storm8.use('*', authMiddleware);
 
+// Resolve which of the user's characters is acting. The Battle tab passes
+// ?character_id=...; we verify ownership and otherwise fall back to slot 1.
+// Returns null if a character_id was provided that the user doesn't own.
+async function actingCharId(db: D1Database, c: any, userId: string): Promise<string | null> {
+  const requested = c.req.query('character_id');
+  if (requested) {
+    const owned = await db
+      .prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+      .bind(requested, userId)
+      .first<{ id: string }>();
+    return owned ? owned.id : null;
+  }
+  const first = await db
+    .prepare('SELECT id FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')
+    .bind(userId)
+    .first<{ id: string }>();
+  return first ? first.id : null;
+}
+
 // ============================================================================
 // SKILL ALLOCATION
 // ============================================================================
@@ -69,9 +88,13 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
     return c.json({ error: 'Must allocate at least 1 point' }, 400);
   }
 
+  const charId = await actingCharId(db, c, user.id);
+  if (!charId) {
+    return c.json({ error: 'Character not found' }, 404);
+  }
   const char = await db
-    .prepare('SELECT unspent_stat_points FROM characters WHERE user_id = ?')
-    .bind(user.id)
+    .prepare('SELECT unspent_stat_points FROM characters WHERE id = ?')
+    .bind(charId)
     .first<{ unspent_stat_points: number }>();
 
   if (!char || totalAllocated > char.unspent_stat_points) {
@@ -93,7 +116,7 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
         current_health = current_health + (? * 10),
         max_energy = 20 + (energy_skill_points + ?),
         max_stamina = 5 + (stamina_skill_points + ?)
-      WHERE user_id = ?
+      WHERE id = ?
     `)
     .bind(
       allocation.attack,
@@ -106,7 +129,7 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
       allocation.health,
       allocation.energy,
       allocation.stamina,
-      user.id
+      charId
     )
     .run();
 
@@ -114,8 +137,8 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
   const allocations = Object.entries(allocation)
     .filter(([_, points]) => points > 0)
     .map(([stat, points]) =>
-      db.prepare('INSERT INTO skill_allocations (character_id, stat_type, points_allocated) VALUES ((SELECT id FROM characters WHERE user_id = ?), ?, ?)')
-        .bind(user.id, stat, points)
+      db.prepare('INSERT INTO skill_allocations (character_id, stat_type, points_allocated) VALUES (?, ?, ?)')
+        .bind(charId, stat, points)
     );
 
   if (allocations.length > 0) {
@@ -133,10 +156,11 @@ storm8.get('/clan', async (c) => {
   const user = c.get('user');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT id, level FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string; level: number }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT id, level FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ id: string; level: number }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -170,10 +194,11 @@ storm8.post('/clan/recruit', zValidator('json', recruitClanSchema), async (c) =>
   const { count } = c.req.valid('json');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT id FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT id FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ id: string }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -208,10 +233,11 @@ storm8.get('/abilities', async (c) => {
   const db = c.env.DB;
   const user = c.get('user');
 
-  const char = await db
-    .prepare('SELECT level FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ level: number }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT level FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ level: number }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -235,10 +261,11 @@ storm8.post('/abilities/purchase', zValidator('json', purchaseAbilitySchema), as
   const { ability_id } = c.req.valid('json');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT id, unbanked_currency, level FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string; unbanked_currency: number; level: number }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT id, unbanked_currency, level FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ id: string; unbanked_currency: number; level: number }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -276,16 +303,17 @@ storm8.get('/abilities/owned', async (c) => {
   const user = c.get('user');
   const db = c.env.DB;
 
-  const owned = await db
+  const charId = await actingCharId(db, c, user.id);
+  const owned = charId ? await db
     .prepare(`
       SELECT a.*, ca.quantity
       FROM character_abilities ca
       JOIN abilities a ON ca.ability_id = a.id
-      WHERE ca.character_id = (SELECT id FROM characters WHERE user_id = ?)
+      WHERE ca.character_id = ?
       ORDER BY a.category, a.attack_value DESC
     `)
-    .bind(user.id)
-    .all();
+    .bind(charId)
+    .all() : { results: [] };
 
   return c.json({ data: owned.results });
 });
@@ -480,11 +508,12 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
   const { defender_character_id } = c.req.valid('json');
   const db = c.env.DB;
 
-  // Get attacker character
-  const attackerChar = await db
-    .prepare('SELECT id FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string }>();
+  // Get attacker character (the one selected in the Battle tab)
+  const attackerCharId = await actingCharId(db, c, user.id);
+  const attackerChar = attackerCharId ? await db
+    .prepare('SELECT id FROM characters WHERE id = ?')
+    .bind(attackerCharId)
+    .first<{ id: string }>() : null;
 
   if (!attackerChar) {
     return c.json({ error: 'Character not found' }, 404);
@@ -702,10 +731,11 @@ storm8.post('/hitlist/post', zValidator('json', postBountySchema), async (c) => 
   const { target_character_id, bounty_amount } = c.req.valid('json');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT id, unbanked_currency FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string; unbanked_currency: number }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT id, unbanked_currency FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ id: string; unbanked_currency: number }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -758,10 +788,11 @@ storm8.post('/hitlist/attack', zValidator('json', attackHitlistSchema), async (c
   const { hitlist_id } = c.req.valid('json');
   const db = c.env.DB;
 
-  const attackerChar = await db
-    .prepare('SELECT id FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string }>();
+  const attackerCharId = await actingCharId(db, c, user.id);
+  const attackerChar = attackerCharId ? await db
+    .prepare('SELECT id FROM characters WHERE id = ?')
+    .bind(attackerCharId)
+    .first<{ id: string }>() : null;
 
   if (!attackerChar) {
     return c.json({ error: 'Character not found' }, 404);
@@ -904,10 +935,11 @@ storm8.post('/hospital/heal', async (c) => {
   const user = c.get('user');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT current_health, max_health, unbanked_currency FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ current_health: number; max_health: number; unbanked_currency: number }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT current_health, max_health, unbanked_currency FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ current_health: number; max_health: number; unbanked_currency: number }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);
@@ -926,8 +958,8 @@ storm8.post('/hospital/heal', async (c) => {
   }
 
   await db
-    .prepare('UPDATE characters SET current_health = max_health, unbanked_currency = unbanked_currency - ? WHERE user_id = ?')
-    .bind(cost, user.id)
+    .prepare('UPDATE characters SET current_health = max_health, unbanked_currency = unbanked_currency - ? WHERE id = ?')
+    .bind(cost, charId)
     .run();
 
   return c.json({ message: `Healed ${hpNeeded} HP for ${cost} currency` });
@@ -941,10 +973,11 @@ storm8.get('/feed', async (c) => {
   const user = c.get('user');
   const db = c.env.DB;
 
-  const char = await db
-    .prepare('SELECT id FROM characters WHERE user_id = ?')
-    .bind(user.id)
-    .first<{ id: string }>();
+  const charId = await actingCharId(db, c, user.id);
+  const char = charId ? await db
+    .prepare('SELECT id FROM characters WHERE id = ?')
+    .bind(charId)
+    .first<{ id: string }>() : null;
 
   if (!char) {
     return c.json({ error: 'Character not found' }, 404);


### PR DESCRIPTION
You can now choose which character fights/builds on the Battle tab (it always used slot 1 before).

## Backend
Every storm8 endpoint picked the acting character with `WHERE user_id = ?` (slot 1). They now resolve it from a **`?character_id=`** query param — ownership-checked, defaulting to slot 1 — via a shared `actingCharId` helper. Applied to: attack, skills/allocate, abilities (list/owned/purchase), clan (view/recruit), hospital/heal, hitlist (post/attack), feed.

## Frontend
The Battle tab loads **all your characters** (`/game/my-characters`) and adds a **"Fighting as"** selector. The chosen character drives every panel (stats, skills, abilities, attack, clan, hitlist, feed) and is sent as `character_id` on each call. Panels are keyed by the selection so they refetch when you switch.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Post-deploy: attack as Caspian and confirm the attacker is Caspian (not truest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)