### PR TITLE
Add respec (reset point allocation)

### DIFF
--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -535,6 +535,18 @@ export default function GameDashboardPage() {
     }
   };
 
+  const handleRespec = async (charId: string) => {
+    if (!confirm('Reset all stat points? Your character returns to base stats and every point is refunded to re-allocate.')) {
+      return;
+    }
+    try {
+      await apiClient.post('/game/character/respec', { characterId: charId });
+      await fetchCharacter(charId);
+    } catch (err: any) {
+      setError(err.message || 'Failed to reset points');
+    }
+  };
+
   if (loading && !slotInfo) return <div className="neon-text">Loading...</div>;
   if (error) return <div className="text-shade-red-600">Error: {error}</div>;
 
@@ -673,6 +685,12 @@ export default function GameDashboardPage() {
               <p className="text-shade-red-100">
                 Unspent Points: {character.unspent_stat_points.toLocaleString()}
               </p>
+              <button
+                onClick={() => handleRespec(character.id)}
+                className="mt-3 w-full bg-shade-black-900 neon-border text-shade-red-400 hover:neon-glow transition-all px-3 py-2 rounded text-sm font-bold"
+              >
+                ↺ Reset Points
+              </button>
             </div>
             <div className="p-4 beveled-panel">
               <h2 className="text-xl font-semibold neon-text">Trophies</h2>

--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -358,9 +358,19 @@ function AbilityShop({ character, onUpdate }: { character: any; onUpdate: () => 
 }
 
 // Shows the stats that actually drive combat, so it's clear what matters.
-function BattleStats({ character }: { character: any }) {
+function BattleStats({ character, onUpdate }: { character: any; onUpdate: () => void }) {
   const cur = character.current_health ?? 0;
   const max = character.max_health ?? 1;
+
+  const handleRespec = async () => {
+    if (!confirm('Reset all stat points? Your character returns to base stats and every point is refunded.')) return;
+    try {
+      await apiClient.post('/game/character/respec', { characterId: character.id });
+      onUpdate();
+    } catch {
+      // ignore — onUpdate refresh will reflect actual state
+    }
+  };
   return (
     <div className="beveled-panel rounded-lg p-6 mb-6">
       <h2 className="text-2xl font-bold mb-2 neon-text">Your Battle Stats</h2>
@@ -381,6 +391,15 @@ function BattleStats({ character }: { character: any }) {
       {cur <= 0 && (
         <p className="text-xs text-shade-red-600 mt-2">💀 Defeated — heal at the hospital to fight again.</p>
       )}
+      <div className="flex justify-between items-center mt-3 text-sm">
+        <span className="text-shade-red-300">Unspent points: <span className="text-shade-red-100 font-bold">{character.unspent_stat_points ?? 0}</span></span>
+        <button
+          onClick={handleRespec}
+          className="bg-shade-black-900 neon-border text-shade-red-400 hover:neon-glow transition-all px-3 py-1.5 rounded text-xs font-bold"
+        >
+          ↺ Reset Points
+        </button>
+      </div>
     </div>
   );
 }
@@ -723,7 +742,7 @@ export default function Storm8Page() {
 
         {/* Right Column */}
         <div>
-          <BattleStats character={character} />
+          <BattleStats character={character} onUpdate={fetchCharacters} />
           <AttackInterface character={character} onUpdate={fetchCharacters} />
           <HitlistBrowser character={character} onUpdate={fetchCharacters} />
           <BattleFeed characterId={character.id} />

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -481,7 +481,7 @@ game.delete('/character/:id', async (c) => {
     return c.json({ message: 'Character deleted. Slot is now available for a new character.', slot: character.slot_number });
 });
 
-import { allocatePointsSchema } from '../shared/schemas/game';
+import { allocatePointsSchema, respecSchema } from '../shared/schemas/game';
 
 // Allocate stat points
 game.post('/character/allocate-points', zValidator('json', allocatePointsSchema), async (c) => {
@@ -536,6 +536,47 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
     ).run();
 
     return c.json({ message: 'Stat points allocated successfully.' });
+});
+
+// Respec: refund every allocated point and reset the character to its class
+// base stats. The full lifetime point budget for the character's level is
+// returned as unspent points so it can be re-allocated.
+game.post('/character/respec', zValidator('json', respecSchema), async (c) => {
+    const user = c.get('user');
+    const { characterId } = c.req.valid('json');
+    const db = c.env.DB;
+
+    const ch = await db
+        .prepare('SELECT id, class, level FROM characters WHERE id = ? AND user_id = ?')
+        .bind(characterId, user.id)
+        .first<{ id: string; class: keyof typeof BASE_STATS; level: number }>();
+
+    if (!ch) {
+        return c.json({ error: 'Character not found or does not belong to you.' }, 404);
+    }
+
+    const base = BASE_STATS[ch.class] ?? BASE_STATS.phoenix;
+    const budget = getTotalStatPointsForLevel(ch.level);
+
+    await db.prepare(`
+        UPDATE characters
+        SET
+            hp = ?, atk = ?, def = ?, mp = ?, spd = ?,
+            attack_skill_points = 0, defense_skill_points = 0, health_skill_points = 0,
+            energy_skill_points = 0, stamina_skill_points = 0,
+            max_health = ?, current_health = ?,
+            max_energy = 20, current_energy = 20,
+            max_stamina = 5, current_stamina = 5,
+            unspent_stat_points = ?
+        WHERE id = ?
+    `).bind(
+        base.hp, base.atk, base.def, base.mp, base.spd,
+        base.hp, base.hp,
+        budget,
+        ch.id
+    ).run();
+
+    return c.json({ message: 'Points reset — all stat points refunded.', unspent_stat_points: budget });
 });
 
 

--- a/workers/src/shared/schemas/game.ts
+++ b/workers/src/shared/schemas/game.ts
@@ -13,6 +13,10 @@ export const firstAccessSchema = z.object({
   }),
 });
 
+export const respecSchema = z.object({
+    characterId: z.string().uuid({ message: 'Invalid character ID' }),
+});
+
 export const allocatePointsSchema = z.object({
     characterId: z.string().uuid({ message: 'Invalid character ID' }),
     hp: z.number().int().min(0).default(0),


### PR DESCRIPTION
Adds a "Reset Points" feature so you can undo your stat allocation and re-spend.

## Backend
New **`POST /game/character/respec`** (ownership-checked). For the chosen character it:
- Resets ATK/DEF/SPD/HP/MP to the class **`BASE_STATS`**.
- Zeroes all storm8 skill points and restores base max health/energy/stamina (and current = max).
- Refunds the **full lifetime point budget** for the character's level via `getTotalStatPointsForLevel` (e.g. 1795 at level 300) as `unspent_stat_points`.

## UI
A **"↺ Reset Points"** button on:
- the **Dashboard** stats panel, and
- the **Battle tab → Your Battle Stats** panel.

Each confirms first, then refreshes the character.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Post-deploy: reset the founder's characters and confirm stats return to base with points refunded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)