### PR TITLE
Health point grants +100 HP everywhere

### DIFF
--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -62,7 +62,7 @@ function SkillAllocation({ character, onUpdate }: { character: any; onUpdate: ()
       case 'defense':
         return `Each point = +${character.level} defense power (scales with level)`;
       case 'health':
-        return 'Each point = +10 max HP';
+        return 'Each point = +100 max HP';
       case 'energy':
         return 'Each point = +1 max energy (for missions)';
       case 'stamina':

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -112,8 +112,8 @@ storm8.post('/skills/allocate', zValidator('json', allocateSkillsSchema), async 
         energy_skill_points = energy_skill_points + ?,
         stamina_skill_points = stamina_skill_points + ?,
         unspent_stat_points = unspent_stat_points - ?,
-        max_health = max_health + (? * 10),
-        current_health = current_health + (? * 10),
+        max_health = max_health + (? * 100),
+        current_health = current_health + (? * 100),
         max_energy = 20 + (energy_skill_points + ?),
         max_stamina = 5 + (stamina_skill_points + ?)
       WHERE id = ?


### PR DESCRIPTION
The Battle tab's health skill point granted only +10 max HP while the Dashboard HP stat gives +100/point. Now both are **+100 per point** so placing a point in health always means +100 HP. Updated the skill description text too.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)