### PR TITLE
Speed grants +2 per allocated point

### DIFF
--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -316,7 +316,7 @@ function AllocatePointsForm({
       <h3 className="text-lg font-bold neon-text">
         You have {character.unspent_stat_points - totalAllocated} unspent stat points!
       </h3>
-      <p className="text-xs text-shade-red-400 mt-1">Each point in HP adds +100 HP. Other stats add +1 per point.</p>
+      <p className="text-xs text-shade-red-400 mt-1">Per point: HP +100, SPD +2, ATK/DEF/MP +1.</p>
       <form onSubmit={handleSubmit} className="space-y-2 mt-2">
         {Object.keys(points).map((stat) => (
           <div key={stat} className="flex items-center justify-between">

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -506,10 +506,11 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
         return c.json({ error: 'Invalid number of points to allocate.' }, 400);
     }
 
-    // Each point spent on HP is worth +100 HP; the other stats are +1 per point.
-    // unspent_stat_points still decreases by the number of points spent. The HP
-    // stat IS the battle health pool, so grow max/current health alongside it.
+    // Per-point gains: HP +100, SPD +2, others +1. unspent_stat_points still
+    // decreases by the number of points spent. The HP stat IS the battle health
+    // pool, so grow max/current health alongside it.
     const HP_PER_POINT = 100;
+    const SPD_PER_POINT = 2;
     const hpGain = pointsToAllocate.hp * HP_PER_POINT;
     await db.prepare(`
         UPDATE characters
@@ -528,7 +529,7 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
         pointsToAllocate.atk,
         pointsToAllocate.def,
         pointsToAllocate.mp,
-        pointsToAllocate.spd,
+        pointsToAllocate.spd * SPD_PER_POINT,
         hpGain,
         hpGain,
         totalPointsToSpend,


### PR DESCRIPTION
Dashboard stat allocation now adds **+2 SPD per point** (HP +100, ATK/DEF/MP +1 unchanged). Updated the allocation hint text.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)