### PR TITLE
Target by character name instead of id

### DIFF
--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -407,12 +407,12 @@ function BattleStats({ character, onUpdate }: { character: any; onUpdate: () => 
 // Attack interface — the resolved battle pops up in the global arena overlay.
 function AttackInterface({ character, onUpdate }: { character: any; onUpdate: () => void }) {
   const { showBattle } = useBattleResult();
-  const [targetId, setTargetId] = useState('');
+  const [targetName, setTargetName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [attacking, setAttacking] = useState(false);
   const [targets, setTargets] = useState<any[]>([]);
 
-  // Load attackable players so the user can pick a target instead of pasting an ID.
+  // Load attackable players so the user can pick a target by name.
   useEffect(() => {
     apiClient.get<{ data: any[] }>('/game/characters')
       .then(r => setTargets(r.data || []))
@@ -421,13 +421,13 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
 
   const handleAttack = async () => {
     setError(null);
-    if (!targetId.trim()) {
+    if (!targetName.trim()) {
       setError('Choose a target');
       return;
     }
     setAttacking(true);
     try {
-      const res = await apiClient.post<{ data: any }>(withChar('/storm8/attack', character?.id), { defender_character_id: targetId.trim() });
+      const res = await apiClient.post<{ data: any }>(withChar('/storm8/attack', character?.id), { defender_gamertag: targetName.trim() });
       showBattle(res.data);
       onUpdate();
     } catch (err: any) {
@@ -460,13 +460,13 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
       <div className="space-y-3">
         {targets.length > 0 && (
           <select
-            value={targetId}
-            onChange={e => setTargetId(e.target.value)}
+            value={targetName}
+            onChange={e => setTargetName(e.target.value)}
             className="w-full p-3 rounded bg-shade-black-600 neon-border text-shade-red-100"
           >
             <option value="">— Choose a target —</option>
             {targets.map(t => (
-              <option key={t.id} value={t.id}>
+              <option key={t.id} value={t.gamertag}>
                 {t.gamertag} (Lv.{t.level} {t.class})
               </option>
             ))}
@@ -474,15 +474,15 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
         )}
         <input
           type="text"
-          value={targetId}
-          onChange={e => setTargetId(e.target.value)}
-          placeholder={targets.length > 0 ? '…or paste a target character ID' : 'Enter target character ID'}
+          value={targetName}
+          onChange={e => setTargetName(e.target.value)}
+          placeholder={targets.length > 0 ? '…or type a character name' : 'Enter a character name'}
           className="w-full p-3 rounded bg-shade-black-600 neon-border text-shade-red-100 placeholder-shade-red-400"
         />
 
         <button
           onClick={handleAttack}
-          disabled={character.current_stamina < 1 || attacking || !targetId.trim()}
+          disabled={character.current_stamina < 1 || attacking || !targetName.trim()}
           className="w-full bg-shade-black-900 neon-border text-shade-red-600 hover:neon-glow-strong transition-all disabled:bg-shade-black-600 disabled:text-shade-red-300 p-3 rounded font-bold text-lg"
         >
           {attacking ? 'Attacking…' : '⚔️ ATTACK (Costs 1 Stamina)'}
@@ -521,12 +521,12 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
   const handlePostHitlist = async () => {
     setError(null);
     if (!postTarget.trim()) {
-      setError('Enter a target character ID');
+      setError('Enter a target character name');
       return;
     }
     try {
       await apiClient.post(withChar('/storm8/hitlist/post', character?.id), {
-        target_character_id: postTarget,
+        target_gamertag: postTarget.trim(),
         bounty_amount: bountyAmount,
       });
       setPostTarget('');
@@ -562,7 +562,7 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
             type="text"
             value={postTarget}
             onChange={e => setPostTarget(e.target.value)}
-            placeholder="Target character ID"
+            placeholder="Target character name"
             className="w-full p-2 rounded bg-shade-black-900 neon-border text-shade-red-100 placeholder-shade-red-400"
           />
           <input

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -495,17 +495,33 @@ function bumpTrophies(
     .bind(characterId, w, l, k, d);
 }
 
+// Resolve a target character by id or (case-insensitive) gamertag/name.
+async function resolveTargetId(db: D1Database, opts: { id?: string; gamertag?: string }): Promise<string | null> {
+  if (opts.id) return opts.id;
+  if (opts.gamertag) {
+    const row = await db
+      .prepare('SELECT id FROM characters WHERE gamertag = ? COLLATE NOCASE')
+      .bind(opts.gamertag.trim())
+      .first<{ id: string }>();
+    return row ? row.id : null;
+  }
+  return null;
+}
+
 // ============================================================================
 // NORMAL BATTLE (PvP Attack)
 // ============================================================================
 
-const attackPlayerSchema = z.object({
-  defender_character_id: z.string(),
-});
+const attackPlayerSchema = z
+  .object({
+    defender_character_id: z.string().optional(),
+    defender_gamertag: z.string().optional(),
+  })
+  .refine((d) => d.defender_character_id || d.defender_gamertag, { message: 'Provide a target name or id' });
 
 storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
   const user = c.get('user');
-  const { defender_character_id } = c.req.valid('json');
+  const { defender_character_id, defender_gamertag } = c.req.valid('json');
   const db = c.env.DB;
 
   // Get attacker character (the one selected in the Battle tab)
@@ -519,7 +535,13 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
     return c.json({ error: 'Character not found' }, 404);
   }
 
-  if (attackerChar.id === defender_character_id) {
+  // Resolve the target by id or name.
+  const defenderId = await resolveTargetId(db, { id: defender_character_id, gamertag: defender_gamertag });
+  if (!defenderId) {
+    return c.json({ error: `No character found named "${defender_gamertag ?? ''}"` }, 404);
+  }
+
+  if (attackerChar.id === defenderId) {
     return c.json({ error: 'Cannot attack yourself' }, 400);
   }
 
@@ -528,7 +550,7 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
 
   // Get stats
   const attackerStats = await getCharacterBattleStats(db, attackerChar.id);
-  const defenderStats = await getCharacterBattleStats(db, defender_character_id);
+  const defenderStats = await getCharacterBattleStats(db, defenderId);
 
   if (!attackerStats || !defenderStats) {
     return c.json({ error: 'Character stats not found' }, 404);
@@ -721,14 +743,17 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
 // HITLIST SYSTEM
 // ============================================================================
 
-const postBountySchema = z.object({
-  target_character_id: z.string(),
-  bounty_amount: z.number().int().min(1000),
-});
+const postBountySchema = z
+  .object({
+    target_character_id: z.string().optional(),
+    target_gamertag: z.string().optional(),
+    bounty_amount: z.number().int().min(1000),
+  })
+  .refine((d) => d.target_character_id || d.target_gamertag, { message: 'Provide a target name or id' });
 
 storm8.post('/hitlist/post', zValidator('json', postBountySchema), async (c) => {
   const user = c.get('user');
-  const { target_character_id, bounty_amount } = c.req.valid('json');
+  const { target_character_id, target_gamertag, bounty_amount } = c.req.valid('json');
   const db = c.env.DB;
 
   const charId = await actingCharId(db, c, user.id);
@@ -741,7 +766,12 @@ storm8.post('/hitlist/post', zValidator('json', postBountySchema), async (c) => 
     return c.json({ error: 'Character not found' }, 404);
   }
 
-  if (char.id === target_character_id) {
+  const targetId = await resolveTargetId(db, { id: target_character_id, gamertag: target_gamertag });
+  if (!targetId) {
+    return c.json({ error: `No character found named "${target_gamertag ?? ''}"` }, 404);
+  }
+
+  if (char.id === targetId) {
     return c.json({ error: 'Cannot hitlist yourself' }, 400);
   }
 
@@ -753,7 +783,7 @@ storm8.post('/hitlist/post', zValidator('json', postBountySchema), async (c) => 
   const hitlistId = crypto.randomUUID();
   await db.batch([
     db.prepare('INSERT INTO hitlist (id, target_character_id, posted_by_character_id, bounty_amount) VALUES (?, ?, ?, ?)')
-      .bind(hitlistId, target_character_id, char.id, bounty_amount),
+      .bind(hitlistId, targetId, char.id, bounty_amount),
     db.prepare('UPDATE characters SET unbanked_currency = unbanked_currency - ? WHERE id = ?')
       .bind(bounty_amount, char.id),
   ]);


### PR DESCRIPTION
Attacks and hitlist bounties can now be aimed by **character name** instead of a raw character ID.

- Backend: `/storm8/attack` accepts `defender_gamertag`; `/storm8/hitlist/post` accepts `target_gamertag` (case-insensitive), resolved to the character. IDs still work.
- Frontend: the Attack target dropdown/field and the Hitlist 'post bounty' field take a name now.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)