### PR TITLE
ATK/DEF % allocation, remove MP, functional ability shop, color pass

### DIFF
--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -281,8 +281,15 @@ function AllocatePointsForm({
   character: Character;
   onAllocationComplete: () => void;
 }) {
-  const [points, setPoints] = useState({ hp: 0, atk: 0, def: 0, mp: 0, spd: 0 });
+  const [points, setPoints] = useState({ hp: 0, atk: 0, def: 0, spd: 0 });
   const [error, setError] = useState<string | null>(null);
+
+  const STAT_META: Record<string, { label: string; hint: string; accent: string; ring: string }> = {
+    hp:  { label: 'HP',  hint: '+100 / pt',     accent: 'text-emerald-400', ring: 'focus:ring-emerald-400' },
+    atk: { label: 'ATK', hint: '+1% base / pt', accent: 'text-rose-400',    ring: 'focus:ring-rose-400' },
+    def: { label: 'DEF', hint: '+1% base / pt', accent: 'text-sky-400',     ring: 'focus:ring-sky-400' },
+    spd: { label: 'SPD', hint: '+2 / pt',       accent: 'text-amber-400',   ring: 'focus:ring-amber-400' },
+  };
 
   const totalAllocated = Object.values(points).reduce((sum, p) => sum + p, 0);
 
@@ -304,7 +311,7 @@ function AllocatePointsForm({
     }
     try {
       await apiClient.post('/game/character/allocate-points', { characterId: character.id, ...points });
-      setPoints({ hp: 0, atk: 0, def: 0, mp: 0, spd: 0 });
+      setPoints({ hp: 0, atk: 0, def: 0, spd: 0 });
       onAllocationComplete();
     } catch (err: any) {
       setError(err.message);
@@ -312,31 +319,33 @@ function AllocatePointsForm({
   };
 
   return (
-    <div className="mt-6 p-4 border border-shade-red-700 rounded">
+    <div className="mt-6 p-5 rounded-xl bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-700/60 shadow-[0_0_25px_rgba(255,42,42,0.15)]">
       <h3 className="text-lg font-bold neon-text">
-        You have {character.unspent_stat_points - totalAllocated} unspent stat points!
+        {character.unspent_stat_points - totalAllocated} unspent stat points
       </h3>
-      <p className="text-xs text-shade-red-400 mt-1">Per point: HP +100, SPD +2, ATK/DEF/MP +1.</p>
-      <form onSubmit={handleSubmit} className="space-y-2 mt-2">
-        {Object.keys(points).map((stat) => (
-          <div key={stat} className="flex items-center justify-between">
-            <label className="uppercase text-shade-red-100">{stat}</label>
+      <p className="text-xs text-shade-red-400 mt-1 mb-3">Spend them to power up. Gains shown per point.</p>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        {(Object.keys(points) as (keyof typeof points)[]).map((stat) => (
+          <div key={stat} className="flex items-center justify-between gap-3 bg-shade-black-800/60 rounded-lg px-3 py-2 border border-white/5">
+            <div className="flex items-baseline gap-2">
+              <span className={`font-bold ${STAT_META[stat].accent}`}>{STAT_META[stat].label}</span>
+              <span className="text-[10px] text-shade-red-400/80">{STAT_META[stat].hint}</span>
+            </div>
             <input
               type="number"
-              value={points[stat as keyof typeof points]}
-              onChange={(e) =>
-                handlePointChange(stat as keyof typeof points, parseInt(e.target.value, 10) || 0)
-              }
-              className="w-24 p-1 rounded bg-shade-black-600 neon-border hover:neon-glow transition-all"
+              min={0}
+              value={points[stat]}
+              onChange={(e) => handlePointChange(stat, parseInt(e.target.value, 10) || 0)}
+              className={`w-24 p-1.5 rounded bg-shade-black-950 border border-white/10 text-shade-red-100 focus:outline-none focus:ring-2 ${STAT_META[stat].ring}`}
             />
           </div>
         ))}
-        {error && <p className="text-shade-red-600">{error}</p>}
+        {error && <p className="text-shade-red-500 text-sm">{error}</p>}
         <button
           type="submit"
-          className="w-full bg-shade-black-900 neon-border text-shade-red-600 hover:neon-glow-strong transition-all p-2 rounded mt-2"
+          className="w-full bg-gradient-to-r from-shade-red-700 to-shade-red-500 text-white font-bold p-2.5 rounded-lg mt-2 hover:from-shade-red-600 hover:to-shade-red-400 transition-all shadow-lg shadow-shade-red-900/40"
         >
-          Allocate Points
+          Allocate {totalAllocated > 0 ? `${totalAllocated} ` : ''}Points
         </button>
       </form>
     </div>
@@ -671,23 +680,31 @@ export default function GameDashboardPage() {
             />
           )}
           <div className="mt-6 grid grid-cols-2 gap-4">
-            <div className="p-4 beveled-panel">
-              <h2 className="text-xl font-semibold neon-text">Stats</h2>
-              <p className="text-shade-red-100">Class: {character.class}</p>
-              <p className="text-shade-red-100">
-                Level: {character.level} ({character.xp.toLocaleString()} XP)
-              </p>
-              <p className="text-shade-red-100">HP: {character.hp.toLocaleString()}</p>
-              <p className="text-shade-red-100">ATK: {character.atk.toLocaleString()}</p>
-              <p className="text-shade-red-100">DEF: {character.def.toLocaleString()}</p>
-              <p className="text-shade-red-100">MP: {character.mp.toLocaleString()}</p>
-              <p className="text-shade-red-100">SPD: {character.spd.toLocaleString()}</p>
-              <p className="text-shade-red-100">
-                Unspent Points: {character.unspent_stat_points.toLocaleString()}
+            <div className="p-5 rounded-xl bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/60 shadow-[0_0_25px_rgba(255,42,42,0.12)]">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-xl font-bold neon-text">Stats</h2>
+                <span className="text-xs px-2 py-1 rounded-full bg-shade-red-900/40 text-shade-red-200 border border-shade-red-700/50 capitalize">{character.class} • Lv.{character.level}</span>
+              </div>
+              <p className="text-xs text-shade-red-400 mb-3">{character.xp.toLocaleString()} XP</p>
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  { label: 'HP', val: character.hp, accent: 'from-emerald-600/30 to-emerald-900/10 text-emerald-300' },
+                  { label: 'ATK', val: character.atk, accent: 'from-rose-600/30 to-rose-900/10 text-rose-300' },
+                  { label: 'DEF', val: character.def, accent: 'from-sky-600/30 to-sky-900/10 text-sky-300' },
+                  { label: 'SPD', val: character.spd, accent: 'from-amber-600/30 to-amber-900/10 text-amber-300' },
+                ].map((s) => (
+                  <div key={s.label} className={`rounded-lg p-3 bg-gradient-to-br ${s.accent} border border-white/10`}>
+                    <div className="text-[10px] uppercase tracking-wider opacity-80">{s.label}</div>
+                    <div className="text-lg font-bold">{s.val.toLocaleString()}</div>
+                  </div>
+                ))}
+              </div>
+              <p className="text-shade-red-200 mt-3 text-sm">
+                Unspent points: <span className="font-bold text-shade-red-100">{character.unspent_stat_points.toLocaleString()}</span>
               </p>
               <button
                 onClick={() => handleRespec(character.id)}
-                className="mt-3 w-full bg-shade-black-900 neon-border text-shade-red-400 hover:neon-glow transition-all px-3 py-2 rounded text-sm font-bold"
+                className="mt-3 w-full bg-shade-black-950 border border-shade-red-700/60 text-shade-red-300 hover:bg-shade-red-900/30 hover:text-shade-red-100 transition-all px-3 py-2 rounded-lg text-sm font-bold"
               >
                 ↺ Reset Points
               </button>

--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -376,10 +376,15 @@ function BattleStats({ character, onUpdate }: { character: any; onUpdate: () => 
       <h2 className="text-2xl font-bold mb-2 neon-text">Your Battle Stats</h2>
       <p className="text-xs text-shade-red-300 mb-3">These drive your damage and survivability. Allocate on the Dashboard.</p>
       <div className="grid grid-cols-4 gap-2 text-center mb-3">
-        {[['ATK', character.atk], ['DEF', character.def], ['SPD', character.spd], ['Class', character.class]].map(([label, val]) => (
-          <div key={label as string} className="bg-shade-black-800 rounded p-2 neon-border">
-            <div className="text-[10px] uppercase text-shade-red-400">{label}</div>
-            <div className="text-shade-red-100 font-semibold truncate">{val ?? 0}</div>
+        {[
+          { label: 'ATK', val: character.atk, accent: 'from-rose-600/30 to-rose-900/10 text-rose-300' },
+          { label: 'DEF', val: character.def, accent: 'from-sky-600/30 to-sky-900/10 text-sky-300' },
+          { label: 'SPD', val: character.spd, accent: 'from-amber-600/30 to-amber-900/10 text-amber-300' },
+          { label: 'Class', val: character.class, accent: 'from-fuchsia-600/30 to-fuchsia-900/10 text-fuchsia-300' },
+        ].map((s) => (
+          <div key={s.label} className={`rounded-lg p-2 bg-gradient-to-br ${s.accent} border border-white/10`}>
+            <div className="text-[10px] uppercase tracking-wider opacity-80">{s.label}</div>
+            <div className="font-bold truncate">{s.val ?? 0}</div>
           </div>
         ))}
       </div>
@@ -483,7 +488,7 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
         <button
           onClick={handleAttack}
           disabled={character.current_stamina < 1 || attacking || !targetName.trim()}
-          className="w-full bg-shade-black-900 neon-border text-shade-red-600 hover:neon-glow-strong transition-all disabled:bg-shade-black-600 disabled:text-shade-red-300 p-3 rounded font-bold text-lg"
+          className="w-full bg-gradient-to-r from-shade-red-700 to-shade-red-500 text-white p-3 rounded-lg font-bold text-lg shadow-lg shadow-shade-red-900/40 hover:from-shade-red-600 hover:to-shade-red-400 transition-all disabled:from-shade-black-700 disabled:to-shade-black-700 disabled:text-shade-red-400 disabled:shadow-none"
         >
           {attacking ? 'Attacking…' : '⚔️ ATTACK (Costs 1 Stamina)'}
         </button>
@@ -713,7 +718,7 @@ export default function Storm8Page() {
   return (
     <div className="p-4 max-w-6xl mx-auto">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-        <h1 className="text-3xl font-bold neon-text">Storm8 Battle System</h1>
+        <h1 className="text-3xl font-extrabold bg-gradient-to-r from-shade-red-400 via-fuchsia-400 to-shade-red-600 bg-clip-text text-transparent tracking-wide">⚔ Battle Arena</h1>
         {/* Character selector: choose which of your characters fights/builds */}
         <div className="flex items-center gap-2">
           <span className="text-sm text-shade-red-300">Fighting as:</span>

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -494,9 +494,9 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
     // Target the specific character the user is editing (and verify ownership),
     // rather than whichever character happens to come back first.
     const character = await db
-        .prepare('SELECT id, unspent_stat_points FROM characters WHERE id = ? AND user_id = ?')
+        .prepare('SELECT id, class, unspent_stat_points FROM characters WHERE id = ? AND user_id = ?')
         .bind(characterId, user.id)
-        .first<{id: string, unspent_stat_points: number}>();
+        .first<{id: string, class: keyof typeof BASE_STATS, unspent_stat_points: number}>();
 
     if (!character) {
         return c.json({ error: 'Character not found or does not belong to you.' }, 404);
@@ -506,19 +506,22 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
         return c.json({ error: 'Invalid number of points to allocate.' }, 400);
     }
 
-    // Per-point gains: HP +100, SPD +2, others +1. unspent_stat_points still
-    // decreases by the number of points spent. The HP stat IS the battle health
-    // pool, so grow max/current health alongside it.
+    // Per-point gains:
+    //   HP  = +100 each
+    //   SPD = +2 each
+    //   ATK/DEF = +1% of the class BASE stat each (100 points = +100% = +base)
+    const base = BASE_STATS[character.class] ?? BASE_STATS.phoenix;
     const HP_PER_POINT = 100;
     const SPD_PER_POINT = 2;
     const hpGain = pointsToAllocate.hp * HP_PER_POINT;
+    const atkGain = Math.round((pointsToAllocate.atk * base.atk) / 100);
+    const defGain = Math.round((pointsToAllocate.def * base.def) / 100);
     await db.prepare(`
         UPDATE characters
         SET
             hp = hp + ?,
             atk = atk + ?,
             def = def + ?,
-            mp = mp + ?,
             spd = spd + ?,
             max_health = max_health + ?,
             current_health = current_health + ?,
@@ -526,9 +529,8 @@ game.post('/character/allocate-points', zValidator('json', allocatePointsSchema)
         WHERE id = ?
     `).bind(
         hpGain,
-        pointsToAllocate.atk,
-        pointsToAllocate.def,
-        pointsToAllocate.mp,
+        atkGain,
+        defGain,
         pointsToAllocate.spd * SPD_PER_POINT,
         hpGain,
         hpGain,

--- a/workers/src/core/storm8-battle-engine.ts
+++ b/workers/src/core/storm8-battle-engine.ts
@@ -92,7 +92,8 @@ function classAttackBonus(stats: CharacterBattleStats): number {
 }
 
 export function calculateAttackPower(stats: CharacterBattleStats): number {
-  const equipmentPower = stats.equipment_attack * stats.usable_clan_members;
+  // Equipment is wielded by you plus your clan; solo players still get it once.
+  const equipmentPower = stats.equipment_attack * Math.max(1, stats.usable_clan_members);
   const skillPower = stats.attack_skill_points * stats.level;
   // The character's ATK stat contributes directly to attack power, plus any
   // class-specific bonus (dragons gain from DEF + SPD).
@@ -104,7 +105,8 @@ export function calculateAttackPower(stats: CharacterBattleStats): number {
  * Total Defense = (equipment_defense × usable_clan_members) + (defense_skill_points × level)
  */
 export function calculateDefensePower(stats: CharacterBattleStats): number {
-  const equipmentPower = stats.equipment_defense * stats.usable_clan_members;
+  // Equipment is wielded by you plus your clan; solo players still get it once.
+  const equipmentPower = stats.equipment_defense * Math.max(1, stats.usable_clan_members);
   const skillPower = stats.defense_skill_points * stats.level;
   // The character's DEF stat contributes directly to defense power.
   return equipmentPower + skillPower + (stats.defense || 0);

--- a/workers/src/shared/schemas/game.ts
+++ b/workers/src/shared/schemas/game.ts
@@ -22,7 +22,6 @@ export const allocatePointsSchema = z.object({
     hp: z.number().int().min(0).default(0),
     atk: z.number().int().min(0).default(0),
     def: z.number().int().min(0).default(0),
-    mp: z.number().int().min(0).default(0),
     spd: z.number().int().min(0).default(0),
 });
 


### PR DESCRIPTION
## ATK / DEF allocate by percentage
Each point in **ATK or DEF** now grants **+1% of the class BASE stat** (so 100 points = +100% = +base). HP (+100) and SPD (+2) per point unchanged.

## MP removed
Dropped the MP stat from allocation and the stats UI.

## Ability shop now functional
Equipment power multiplied by clan size, which is 0 for solo players → bought abilities did nothing. Floored the multiplier at **×1**, so abilities now add their ATK/DEF in battle.

## Color / design pass
Color-coded stat tiles (HP=emerald, ATK=rose, DEF=sky, SPD=amber), gradient panels and buttons, and a gradient "⚔ Battle Arena" title on the Battle tab + a refreshed dashboard stats/allocation panel.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Post-deploy: confirm 100 ATK points ≈ +base ATK; abilities raise battle damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)