### PR TITLE
Color/design pass across the game pages + functional leaderboard

### DIFF
--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -639,19 +639,19 @@ export default function GameDashboardPage() {
 
       <div className="flex gap-2 mb-4">
         <button
-          className="px-4 py-2 bg-shade-black-700 neon-border text-shade-red-500 rounded"
+          className="px-4 py-2 rounded-lg font-bold bg-gradient-to-r from-shade-red-700 to-shade-red-500 text-white shadow-lg shadow-shade-red-900/40"
         >
           Dashboard
         </button>
         <Link
           to="/shade/profile"
-          className="px-4 py-2 bg-shade-black-800 border border-shade-red-800 text-shade-red-400 rounded hover:border-shade-red-600 transition-all"
+          className="px-4 py-2 rounded-lg bg-shade-black-800 border border-shade-red-800/60 text-shade-red-300 hover:border-fuchsia-500/60 hover:text-fuchsia-300 transition-all"
         >
           Gamer Profile
         </Link>
         <button
           onClick={() => setView('story')}
-          className="px-4 py-2 bg-shade-black-800 border border-shade-red-800 text-shade-red-400 rounded hover:border-shade-red-600 transition-all"
+          className="px-4 py-2 rounded-lg bg-shade-black-800 border border-shade-red-800/60 text-shade-red-300 hover:border-amber-500/60 hover:text-amber-300 transition-all"
         >
           Story Mode
         </button>
@@ -709,15 +709,24 @@ export default function GameDashboardPage() {
                 ↺ Reset Points
               </button>
             </div>
-            <div className="p-4 beveled-panel">
-              <h2 className="text-xl font-semibold neon-text">Trophies</h2>
-              <p className="text-shade-red-100">Wins: {character.wins}</p>
-              <p className="text-shade-red-100">Losses: {character.losses}</p>
-              <p className="text-shade-red-100">Kills: {character.kills}</p>
-              <p className="text-shade-red-100">Deaths: {character.deaths}</p>
+            <div className="p-5 rounded-xl bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/60">
+              <h2 className="text-xl font-bold neon-text mb-3">Trophies</h2>
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  { label: 'Wins', val: character.wins, c: 'text-emerald-300' },
+                  { label: 'Losses', val: character.losses, c: 'text-shade-red-300' },
+                  { label: 'Kills', val: character.kills, c: 'text-fuchsia-300' },
+                  { label: 'Deaths', val: character.deaths, c: 'text-sky-300' },
+                ].map((s) => (
+                  <div key={s.label} className="rounded-lg p-3 bg-shade-black-950/60 border border-white/10">
+                    <div className="text-[10px] uppercase tracking-wider text-shade-red-400">{s.label}</div>
+                    <div className={`text-lg font-bold ${s.c}`}>{s.val ?? 0}</div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className="p-4 beveled-panel col-span-2">
-              <h2 className="text-xl font-semibold neon-text">Active Battles</h2>
+            <div className="p-5 rounded-xl col-span-2 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/60">
+              <h2 className="text-xl font-bold neon-text">Active Battles</h2>
               <div className="space-y-2 mt-2">
                 {battles.length > 0 ? (
                   battles.map((b) => (

--- a/app/routes/game.leaderboard.tsx
+++ b/app/routes/game.leaderboard.tsx
@@ -1,8 +1,74 @@
+import { useEffect, useState } from "react";
+import { apiClient } from "../lib/api";
+
+type Row = {
+  id: string;
+  gamertag: string;
+  class: string;
+  level: number;
+  wins: number;
+  losses: number;
+  kills: number;
+  deaths: number;
+};
+
+const RANK_STYLE = [
+  "from-amber-500/40 to-amber-900/10 border-amber-400/50 text-amber-200",   // 1st – gold
+  "from-slate-300/30 to-slate-700/10 border-slate-300/40 text-slate-200",   // 2nd – silver
+  "from-orange-700/40 to-orange-950/10 border-orange-600/50 text-orange-200", // 3rd – bronze
+];
+
 export default function GameLeaderboardPage() {
-    return (
-        <div>
-            <h1 className="text-2xl font-bold neon-text">Leaderboard</h1>
-            <p className="text-shade-red-100">Game rankings will be displayed here.</p>
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient.get<{ data: Row[] }>("/game/leaderboard")
+      .then((r) => setRows(r.data || []))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-3xl font-extrabold mb-1 bg-gradient-to-r from-amber-300 via-shade-red-400 to-fuchsia-400 bg-clip-text text-transparent tracking-wide">
+        🏆 Leaderboard
+      </h1>
+      <p className="text-sm text-shade-red-300 mb-5">Top fighters by level, wins, and kills.</p>
+
+      {loading && <p className="neon-text">Loading rankings…</p>}
+      {error && <p className="text-shade-red-500">{error}</p>}
+      {!loading && rows.length === 0 && (
+        <div className="rounded-xl p-8 text-center bg-gradient-to-br from-shade-black-800 to-black border border-shade-red-800/50 text-shade-red-300">
+          No ranked fighters yet — be the first to climb.
         </div>
-    );
+      )}
+
+      <div className="space-y-2">
+        {rows.map((r, i) => (
+          <div
+            key={r.id}
+            className={`flex items-center gap-4 rounded-xl p-3 border bg-gradient-to-r ${
+              i < 3 ? RANK_STYLE[i] : "from-shade-black-800 to-shade-black-900 border-white/10 text-shade-red-100"
+            }`}
+          >
+            <div className="w-9 text-center text-xl font-extrabold">
+              {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `#${i + 1}`}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-bold truncate">{r.gamertag}</div>
+              <div className="text-xs opacity-70 capitalize">{r.class} • Lv.{r.level}</div>
+            </div>
+            <div className="flex gap-3 text-center text-xs">
+              <div><div className="font-bold text-emerald-300">{r.wins}</div><div className="opacity-60">W</div></div>
+              <div><div className="font-bold text-shade-red-300">{r.losses}</div><div className="opacity-60">L</div></div>
+              <div><div className="font-bold text-fuchsia-300">{r.kills}</div><div className="opacity-60">K</div></div>
+              <div><div className="font-bold text-sky-300">{r.deaths}</div><div className="opacity-60">D</div></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/app/routes/game.players.tsx
+++ b/app/routes/game.players.tsx
@@ -77,7 +77,7 @@ export default function PlayersPage() {
 
     return (
         <div>
-            <h1 className="text-2xl font-bold mb-4 neon-text">Find Someone to Attack</h1>
+            <h1 className="text-3xl font-extrabold mb-4 bg-gradient-to-r from-shade-red-400 via-fuchsia-400 to-shade-red-600 bg-clip-text text-transparent tracking-wide">Find Someone to Attack</h1>
             {attackStatus && (
                 <div className="mb-4 rounded border border-shade-red-600 bg-shade-black-700 px-3 py-2 text-sm text-shade-red-100">
                     {attackStatus}
@@ -92,15 +92,20 @@ export default function PlayersPage() {
                         <div className="p-4 beveled-panel text-shade-red-100">No in-game players available to attack right now.</div>
                     )}
                     {players.map(player => (
-                        <div key={player.id} className="p-4 beveled-panel flex justify-between items-center">
-                            <div>
-                                <p className="font-bold neon-text">{player.gamertag}</p>
-                                <p className="text-sm text-shade-black-400">Lvl {player.level} {player.class}</p>
+                        <div key={player.id} className="p-4 rounded-xl flex justify-between items-center bg-gradient-to-r from-shade-black-800 to-shade-black-900 border border-shade-red-800/40 hover:border-shade-red-600/70 transition-all">
+                            <div className="flex items-center gap-3 min-w-0">
+                                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-shade-red-700 to-fuchsia-700 flex items-center justify-center font-bold text-white shrink-0">
+                                    {player.gamertag?.charAt(0).toUpperCase()}
+                                </div>
+                                <div className="min-w-0">
+                                    <p className="font-bold text-shade-red-100 truncate">{player.gamertag}</p>
+                                    <p className="text-xs text-shade-red-400 capitalize">Lv.{player.level} {player.class}</p>
+                                </div>
                             </div>
                             <button
                                 onClick={() => handleAttack(player.id)}
-                                className="bg-shade-black-900 neon-border text-shade-red-600 hover:neon-glow-strong transition-all px-4 py-2 rounded">
-                                Attack
+                                className="bg-gradient-to-r from-shade-red-700 to-shade-red-500 text-white font-bold px-4 py-2 rounded-lg shadow-lg shadow-shade-red-900/40 hover:from-shade-red-600 hover:to-shade-red-400 transition-all">
+                                ⚔ Attack
                             </button>
                         </div>
                     ))}

--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -73,7 +73,7 @@ function SkillAllocation({ character, onUpdate }: { character: any; onUpdate: ()
   };
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Skill Allocation</h2>
       <p className="text-xs text-shade-red-300 mb-3 bg-shade-black-800 p-2 rounded neon-border">
         These spend the <span className="text-shade-red-100">same unspent points</span> as the Dashboard.
@@ -174,7 +174,7 @@ function ClanManagement({ characterId, onUpdate }: { characterId?: string | null
   if (loading) return <div>Loading clan data...</div>;
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Clan Management</h2>
 
       {clanData && (
@@ -270,7 +270,7 @@ function AbilityShop({ character, onUpdate }: { character: any; onUpdate: () => 
   if (loading) return <div>Loading abilities...</div>;
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Ability Shop</h2>
 
       <div className="flex gap-2 mb-4">
@@ -372,7 +372,7 @@ function BattleStats({ character, onUpdate }: { character: any; onUpdate: () => 
     }
   };
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-2 neon-text">Your Battle Stats</h2>
       <p className="text-xs text-shade-red-300 mb-3">These drive your damage and survivability. Allocate on the Dashboard.</p>
       <div className="grid grid-cols-4 gap-2 text-center mb-3">
@@ -443,7 +443,7 @@ function AttackInterface({ character, onUpdate }: { character: any; onUpdate: ()
   };
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Attack</h2>
 
       <div className="bg-shade-black-600 neon-border p-4 rounded mb-4">
@@ -557,7 +557,7 @@ function HitlistBrowser({ character, onUpdate }: { character: any; onUpdate: () 
   if (loading) return <div>Loading hitlist...</div>;
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Hitlist</h2>
 
       <div className="bg-shade-black-600 neon-border p-4 rounded mb-4">
@@ -645,7 +645,7 @@ function BattleFeed({ characterId }: { characterId?: string | null }) {
   if (loading) return <div>Loading battle feed...</div>;
 
   return (
-    <div className="beveled-panel rounded-lg p-6 mb-6">
+    <div className="rounded-xl p-6 mb-6 bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50 shadow-[0_0_20px_rgba(255,42,42,0.10)]">
       <h2 className="text-2xl font-bold mb-4 neon-text">Battle Feed</h2>
 
       <div className="space-y-2">

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -375,6 +375,22 @@ game.get('/characters', async (c) => {
     return c.json({ data: characters.results });
 });
 
+// Global leaderboard: top fighters by level, then wins, then kills.
+game.get('/leaderboard', async (c) => {
+    const db = c.env.DB;
+    const rows = await db.prepare(`
+        SELECT c.id, c.gamertag, c.class, c.level,
+               COALESCE(t.wins,0) AS wins, COALESCE(t.losses,0) AS losses,
+               COALESCE(t.kills,0) AS kills, COALESCE(t.deaths,0) AS deaths
+        FROM characters c
+        LEFT JOIN trophies t ON t.character_id = c.id
+        WHERE c.first_game_access_completed = TRUE
+        ORDER BY c.level DESC, wins DESC, kills DESC
+        LIMIT 25
+    `).all();
+    return c.json({ data: rows.results || [] });
+});
+
 // Get all user's characters
 game.get('/my-characters', async (c) => {
     const user = c.get('user');


### PR DESCRIPTION
Extends the richer, more colorful styling across the **game (/shade) pages**.

- **Leaderboard**: was an empty stub — now a real ranked board (new `GET /game/leaderboard`, top 25 by level/wins/kills) with gold/silver/bronze rows and W/L/K/D.
- **Find Players**: gradient player cards with avatar initials + gradient Attack buttons.
- **Battle tab**: all sub-panels use gradient cards; gradient '⚔ Battle Arena' title; color-coded stat tiles (HP/ATK/DEF/SPD); gradient Attack button.
- **Dashboard**: gradient Stats & Trophies cards with colored stat tiles, gradient view-toggle and allocation panel.

Social side left unchanged (game pages only).

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)