### PR TITLE
Active Battles panel only shows active battles

### DIFF
--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -695,9 +695,13 @@ game.get('/battles', authMiddleware, async (c) => {
     const character = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(user.id).first<{id: string}>();
     if (!character) return c.json({ data: [] });
 
-    const battles = await db.prepare('SELECT * FROM battles WHERE attacker_char_id = ? OR defender_char_id = ? ORDER BY started_at DESC')
-        .bind(character.id, character.id)
-        .all();
+    // Only genuinely active battles — completed history doesn't belong here.
+    const battles = await db.prepare(`
+        SELECT * FROM battles
+        WHERE (attacker_char_id = ? OR defender_char_id = ?)
+          AND state IN ('pending', 'active')
+        ORDER BY started_at DESC
+    `).bind(character.id, character.id).all();
 
     return c.json({ data: battles.results });
 });


### PR DESCRIPTION
GET /game/battles returned all battles regardless of state, so completed history showed in the dashboard's 'Active Battles' panel. Now filtered to state in ('pending','active') — instant-resolution storm8 battles leave it empty, as expected.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)