### PR TITLE
Public gamertags + case-insensitive gamertag uniqueness

### DIFF
--- a/app/routes/battles.$id.tsx
+++ b/app/routes/battles.$id.tsx
@@ -66,7 +66,7 @@ export default function BattlePage() {
 
     return (
         <div>
-            <h1 className="text-2xl font-bold mb-4 neon-text">Battle: {battle.attacker_char_id} vs {battle.defender_char_id}</h1>
+            <h1 className="text-2xl font-bold mb-4 neon-text">Battle: {battle.attacker_gamertag ?? 'Unknown'} vs {battle.defender_gamertag ?? 'Unknown'}</h1>
             <p className="text-shade-red-100">Status: <span className="font-semibold neon-text">{battle.state}</span></p>
 
             {isMyTurn && (
@@ -76,7 +76,7 @@ export default function BattlePage() {
             )}
             {battle.state === 'completed' && (
                 <div className="my-4 space-y-3">
-                    <p className="text-lg font-bold text-shade-red-400">Winner: {battle.winner_char_id}</p>
+                    <p className="text-lg font-bold text-shade-red-400">Winner: {battle.winner_gamertag ?? 'Unknown'}</p>
                     {opponentId && (
                         <div className="flex items-center gap-3">
                             <button
@@ -97,7 +97,7 @@ export default function BattlePage() {
                 <div className="space-y-2 mt-2">
                     {battle.turns.map((turn: any) => (
                         <div key={turn.id} className="p-2 beveled-panel">
-                           <p className="text-shade-red-100">Turn {turn.turn_index}: {turn.actor_char_id} attacks, dealing {turn.damage} damage.</p>
+                           <p className="text-shade-red-100">Turn {turn.turn_index}: {turn.actor_char_id === battle.defender_char_id ? (battle.defender_gamertag ?? 'Defender') : (battle.attacker_gamertag ?? 'Attacker')} attacks, dealing {turn.damage} damage.</p>
                            <p className="text-xs text-shade-black-400">Target HP after: {turn.hp_after_target}</p>
                         </div>
                     ))}

--- a/migrations/0013_gamertag_unique_nocase.sql
+++ b/migrations/0013_gamertag_unique_nocase.sql
@@ -1,0 +1,7 @@
+-- Enforce case-insensitive uniqueness of character gamertags (the public-facing
+-- username). The column was already UNIQUE but case-sensitively, so "truest"
+-- and "Truest" could both exist. NULLs (characters that haven't picked a name
+-- yet) remain allowed and don't collide.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_characters_gamertag_nocase
+  ON characters (gamertag COLLATE NOCASE);

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -179,7 +179,7 @@ game.post('/characters/create', zValidator('json', createCharacterSchema), async
 
   try {
     // Check if gamertag is unique
-    const existingGamertag = await db.prepare('SELECT id FROM characters WHERE gamertag = ?').bind(gamertag).first();
+    const existingGamertag = await db.prepare('SELECT id FROM characters WHERE gamertag = ? COLLATE NOCASE').bind(gamertag).first();
     if (existingGamertag) {
       return c.json({ error: 'Gamertag is already taken.' }, 409);
     }
@@ -277,7 +277,7 @@ game.post('/first-access', zValidator('json', firstAccessSchema), async (c) => {
     }
 
     // 2. Check if gamertag is unique
-    const existingGamertag = await db.prepare('SELECT id FROM characters WHERE gamertag = ?').bind(gamertag).first();
+    const existingGamertag = await db.prepare('SELECT id FROM characters WHERE gamertag = ? COLLATE NOCASE').bind(gamertag).first();
     if (existingGamertag) {
       return c.json({ error: 'Gamertag is already taken.' }, 409);
     }
@@ -344,7 +344,7 @@ game.post('/character/customize', zValidator('json', customizeCharacterSchema), 
     }
 
     if (gamertag) {
-      const taken = await db.prepare('SELECT 1 FROM characters WHERE gamertag = ? AND id != ?').bind(gamertag, ch.id).first();
+      const taken = await db.prepare('SELECT 1 FROM characters WHERE gamertag = ? COLLATE NOCASE AND id != ?').bind(gamertag, ch.id).first();
       if (taken) return c.json({ error: 'Gamertag is already taken.' }, 409);
     }
 
@@ -711,14 +711,28 @@ game.get('/battles/:id', async (c) => {
     const battleId = c.req.param('id');
     const db = c.env.DB;
 
-    const battle = await db.prepare('SELECT * FROM battles WHERE id = ?').bind(battleId).first();
+    const battle = await db.prepare('SELECT * FROM battles WHERE id = ?').bind(battleId).first<BattleRow>();
     if (!battle) return c.json({ error: 'Battle not found' }, 404);
 
     const turns = await db.prepare('SELECT * FROM battle_turns WHERE battle_id = ? ORDER BY turn_index ASC').bind(battleId).all();
 
-    // We could also join with character tables to get gamertags
+    // Resolve gamertags so the UI never shows raw character ids.
+    const names = await db
+        .prepare('SELECT id, gamertag FROM characters WHERE id IN (?, ?)')
+        .bind(battle.attacker_char_id, battle.defender_char_id)
+        .all<{ id: string; gamertag: string }>();
+    const nameOf = (id: string | null | undefined) =>
+        (id && names.results?.find((r) => r.id === id)?.gamertag) || 'Unknown';
 
-    return c.json({ data: { ...battle, turns: turns.results } });
+    return c.json({
+        data: {
+            ...battle,
+            attacker_gamertag: nameOf(battle.attacker_char_id),
+            defender_gamertag: nameOf(battle.defender_char_id),
+            winner_gamertag: nameOf(battle.winner_char_id),
+            turns: turns.results,
+        },
+    });
 });
 
 // Submit a turn for a battle (DEPRECATED - battles now resolve instantly)


### PR DESCRIPTION
## Public-facing names
The legacy battle page was the last place showing raw character IDs. `GET /game/battles/:id` now returns `attacker_gamertag`/`defender_gamertag`/`winner_gamertag`, and the page shows names in the title, winner line, and turn log. (Battle arena, leaderboard, hitlist, find-players, and profile already used gamertags.) Character IDs stay internal.

## Username uniqueness
- gamertag was already `UNIQUE` but case-sensitively. Made the create / first-access / customize checks **case-insensitive** (`COLLATE NOCASE`) and added **migration 0013**: a case-insensitive UNIQUE index, so `truest` and `Truest` can't both exist.
- Current data: all non-null gamertags are already unique (index applied with no conflict). The only repeated value was `NULL` — 3 characters that haven't picked a name yet — which is allowed and doesn't collide.

npm run build ✅ • typecheck ✅ • migration applied to remote ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)