### PR TITLE
Global active character, profile comments, click-name-to-profile

### DIFF
--- a/app/components/ProfileComments.tsx
+++ b/app/components/ProfileComments.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { apiClient } from "../lib/api";
+import { useAuth } from "../lib/AuthContext";
+
+type Comment = {
+  id: string;
+  body: string;
+  created_at: string;
+  author: string;
+  author_user_id: string;
+};
+
+// Comment wall for a gamer profile. `name` is a username or a character gamertag.
+export function ProfileComments({ name }: { name: string }) {
+  const { user, isAuthenticated } = useAuth();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [body, setBody] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [posting, setPosting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const r = await apiClient.get<{ data: Comment[] }>(`/game/profile/${encodeURIComponent(name)}/comments`);
+      setComments(r.data || []);
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (name) load();
+  }, [name]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setPosting(true);
+    setError(null);
+    try {
+      await apiClient.post(`/game/profile/${encodeURIComponent(name)}/comments`, { body: body.trim() });
+      setBody("");
+      await load();
+    } catch (err: any) {
+      setError(err?.message || "Failed to post comment");
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await apiClient.delete(`/game/comments/${id}`);
+      await load();
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="p-5 rounded-xl bg-gradient-to-br from-shade-black-800 via-shade-black-900 to-black border border-shade-red-800/50">
+      <h2 className="text-lg font-bold neon-text mb-3">Comments</h2>
+
+      {isAuthenticated && (
+        <form onSubmit={submit} className="flex gap-2 mb-4">
+          <input
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            maxLength={500}
+            placeholder="Leave a comment…"
+            className="flex-1 p-2 rounded bg-shade-black-950 border border-white/10 text-shade-red-100 focus:outline-none focus:ring-2 focus:ring-shade-red-500"
+          />
+          <button
+            disabled={posting || !body.trim()}
+            className="px-4 py-2 rounded-lg bg-gradient-to-r from-shade-red-700 to-shade-red-500 text-white font-bold disabled:opacity-50"
+          >
+            Post
+          </button>
+        </form>
+      )}
+      {error && <p className="text-shade-red-500 text-sm mb-2">{error}</p>}
+
+      {loading ? (
+        <p className="text-shade-red-400 text-sm">Loading…</p>
+      ) : comments.length === 0 ? (
+        <p className="text-shade-red-400 text-sm">No comments yet — be the first.</p>
+      ) : (
+        <div className="space-y-2">
+          {comments.map((c) => (
+            <div key={c.id} className="p-3 rounded-lg bg-shade-black-950/60 border border-white/10">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-bold text-shade-red-200">{c.author}</span>
+                <span className="text-[10px] text-shade-red-500">{new Date(c.created_at).toLocaleString()}</span>
+              </div>
+              <p className="text-shade-red-100 text-sm mt-1 break-words">{c.body}</p>
+              {user?.id === c.author_user_id && (
+                <button onClick={() => remove(c.id)} className="text-[10px] text-shade-red-500 hover:text-shade-red-300 mt-1">
+                  delete
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/lib/ActiveCharacterContext.tsx
+++ b/app/lib/ActiveCharacterContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import type { ReactNode } from "react";
+import { apiClient } from "./api";
+import { useAuth } from "./AuthContext";
+
+type Char = any;
+
+type ActiveCharacterContextType = {
+  characters: Char[];
+  activeId: string | null;
+  activeCharacter: Char | null;
+  setActive: (id: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  loading: boolean;
+};
+
+const ActiveCharacterContext = createContext<ActiveCharacterContextType | undefined>(undefined);
+
+// Tracks the character the user is "playing as". Persisted server-side so every
+// game action defaults to it until the user switches.
+export function ActiveCharacterProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated, user } = useAuth();
+  const [characters, setCharacters] = useState<Char[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await apiClient.get<{ data: Char[] }>("/game/my-characters");
+      const list = (res.data || []).filter((ch: any) => ch.first_game_access_completed);
+      setCharacters(list);
+      setActiveId((prev) => {
+        const valid = (id: string | null | undefined) =>
+          id && list.some((ch: any) => ch.id === id) ? id : null;
+        return valid(prev) || valid(user?.active_character_id) || (list[0]?.id ?? null);
+      });
+    } catch {
+      // leave as-is
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.active_character_id]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      refresh();
+    } else {
+      setCharacters([]);
+      setActiveId(null);
+      setLoading(false);
+    }
+  }, [isAuthenticated, refresh]);
+
+  const setActive = useCallback(async (id: string) => {
+    setActiveId(id);
+    try {
+      await apiClient.post("/game/active-character", { characterId: id });
+    } catch {
+      // non-fatal; the server default still applies on next load
+    }
+  }, []);
+
+  const activeCharacter = characters.find((c) => c.id === activeId) ?? null;
+
+  return (
+    <ActiveCharacterContext.Provider value={{ characters, activeId, activeCharacter, setActive, refresh, loading }}>
+      {children}
+    </ActiveCharacterContext.Provider>
+  );
+}
+
+export function useActiveCharacter() {
+  const ctx = useContext(ActiveCharacterContext);
+  if (!ctx) throw new Error("useActiveCharacter must be used within an ActiveCharacterProvider");
+  return ctx;
+}

--- a/app/lib/AuthContext.tsx
+++ b/app/lib/AuthContext.tsx
@@ -12,6 +12,7 @@ interface User {
   bio?: string;
   has_password?: boolean;
   shade_avatar_url?: string | null;
+  active_character_id?: string | null;
 }
 
 interface AuthContextType {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,6 +11,7 @@ import { VoiceAssistant } from "./components/VoiceAssistant";
 import { AuthProvider } from "./lib/AuthContext";
 import { VoiceAssistantProvider } from "./lib/VoiceAssistantContext";
 import { BattleResultProvider } from "./lib/BattleResultContext";
+import { ActiveCharacterProvider } from "./lib/ActiveCharacterContext";
 
 import type { Route } from "./+types/root";
 import "./app.css";
@@ -39,6 +40,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body className="bg-black text-shade-red-100">
         <AuthProvider>
+          <ActiveCharacterProvider>
           <BattleResultProvider>
             <VoiceAssistantProvider>
               <NavBar />
@@ -48,6 +50,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               <VoiceAssistant />
             </VoiceAssistantProvider>
           </BattleResultProvider>
+          </ActiveCharacterProvider>
         </AuthProvider>
         <ScrollRestoration />
         <Scripts />

--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { apiClient } from '../lib/api';
 import { useAuth } from '../lib/AuthContext';
+import { useActiveCharacter } from '../lib/ActiveCharacterContext';
 import { SquarePayment } from '../components/SquarePayment';
 
 type SlotInfo = {
@@ -436,6 +437,7 @@ function PurchaseSlotModal({
 
 export default function GameDashboardPage() {
   const { user } = useAuth();
+  const { activeId, setActive } = useActiveCharacter();
   const [slotInfo, setSlotInfo] = useState<SlotInfo | null>(null);
   const [character, setCharacter] = useState<Character | null>(null);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
@@ -451,8 +453,9 @@ export default function GameDashboardPage() {
       const res = await apiClient.get<{ data: SlotInfo }>('/game/slots');
       setSlotInfo(res.data);
 
-      // Auto-select first completed character
-      const completedChar = res.data.characters.find((c) => c.first_game_access_completed);
+      // Prefer the globally active character; else first completed character.
+      const activeChar = res.data.characters.find((c) => c.id === activeId && c.first_game_access_completed);
+      const completedChar = activeChar || res.data.characters.find((c) => c.first_game_access_completed);
       if (completedChar && !selectedCharacterId) {
         setSelectedCharacterId(completedChar.id);
       }
@@ -502,12 +505,13 @@ export default function GameDashboardPage() {
 
   const handleSelectCharacter = (id: string) => {
     const char = slotInfo?.characters.find((c) => c.id === id);
-    if (char && !char.first_game_access_completed) {
-      setSelectedCharacterId(id);
-      setView('setup');
-    } else {
-      setSelectedCharacterId(id);
+    setSelectedCharacterId(id);
+    // A completed character becomes the one you're "playing as" everywhere.
+    if (char && char.first_game_access_completed) {
+      setActive(id);
       setView('dashboard');
+    } else {
+      setView('setup');
     }
   };
 

--- a/app/routes/game.players.tsx
+++ b/app/routes/game.players.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { apiClient } from '../lib/api';
 import { useAuth } from '../lib/AuthContext';
 import { useBattleResult } from '../lib/BattleResultContext';
@@ -98,7 +99,7 @@ export default function PlayersPage() {
                                     {player.gamertag?.charAt(0).toUpperCase()}
                                 </div>
                                 <div className="min-w-0">
-                                    <p className="font-bold text-shade-red-100 truncate">{player.gamertag}</p>
+                                    <Link to={`/shade/u/${encodeURIComponent(player.gamertag)}`} className="font-bold text-shade-red-100 truncate hover:underline block">{player.gamertag}</Link>
                                     <p className="text-xs text-shade-red-400 capitalize">Lv.{player.level} {player.class}</p>
                                 </div>
                             </div>

--- a/app/routes/game.storm8.tsx
+++ b/app/routes/game.storm8.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { apiClient } from '../lib/api';
 import { HpBar } from '../components/BattleArena';
 import { useBattleResult } from '../lib/BattleResultContext';
+import { useActiveCharacter } from '../lib/ActiveCharacterContext';
 
 // Append the acting character to a storm8 API path so the server acts on the
 // character selected in the Battle tab (not just slot 1).
@@ -647,7 +649,8 @@ function BattleFeed({ characterId }: { characterId?: string | null }) {
               <div className="flex justify-between items-start">
                 <div>
                   <p className="font-bold text-shade-red-100">
-                    {battle.attacker_won ? '✓ Victory' : '✗ Defeat'} vs {battle.defender_gamertag}
+                    {battle.attacker_won ? '✓ Victory' : '✗ Defeat'} vs{' '}
+                    <Link to={`/shade/u/${encodeURIComponent(battle.defender_gamertag)}`} className="hover:underline">{battle.defender_gamertag}</Link>
                   </p>
                   <p className="text-sm text-shade-red-300">
                     Damage: {battle.damage_dealt} | Stolen: {battle.currency_stolen}
@@ -670,44 +673,23 @@ function BattleFeed({ characterId }: { characterId?: string | null }) {
 
 // Main Storm8 Page
 export default function Storm8Page() {
-  const [characters, setCharacters] = useState<any[]>([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchCharacters = async () => {
-    try {
-      const res = await apiClient.get<{ data: any[] }>('/game/my-characters');
-      const list = (res.data || []).filter((ch) => ch.first_game_access_completed);
-      setCharacters(list);
-      setSelectedId((prev) => (prev && list.some((ch) => ch.id === prev) ? prev : list[0]?.id ?? null));
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchCharacters();
-  }, []);
-
-  const character = characters.find((ch) => ch.id === selectedId) ?? null;
+  const { characters, activeId, activeCharacter, setActive, refresh, loading } = useActiveCharacter();
 
   if (loading) return <div className="p-4 text-shade-red-200">Loading...</div>;
-  if (error) return <div className="p-4 text-shade-red-600">Error: {error}</div>;
-  if (!character) return <div className="p-4 text-shade-red-300">No character found. Create one on the Dashboard.</div>;
+  if (!activeCharacter) return <div className="p-4 text-shade-red-300">No character found. Create one on the Dashboard.</div>;
+
+  const character = activeCharacter;
 
   return (
     <div className="p-4 max-w-6xl mx-auto">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <h1 className="text-3xl font-extrabold bg-gradient-to-r from-shade-red-400 via-fuchsia-400 to-shade-red-600 bg-clip-text text-transparent tracking-wide">⚔ Battle Arena</h1>
-        {/* Character selector: choose which of your characters fights/builds */}
+        {/* Playing-as selector: shared everywhere via the active character. */}
         <div className="flex items-center gap-2">
-          <span className="text-sm text-shade-red-300">Fighting as:</span>
+          <span className="text-sm text-shade-red-300">Playing as:</span>
           <select
-            value={selectedId ?? ''}
-            onChange={(e) => setSelectedId(e.target.value)}
+            value={activeId ?? ''}
+            onChange={(e) => setActive(e.target.value)}
             className="p-2 rounded bg-shade-black-600 neon-border text-shade-red-100"
           >
             {characters.map((ch) => (
@@ -719,20 +701,20 @@ export default function Storm8Page() {
         </div>
       </div>
 
-      {/* Keyed by selectedId so panels refetch when you switch characters */}
-      <div className="grid md:grid-cols-2 gap-6" key={selectedId}>
+      {/* Keyed by activeId so panels refetch when you switch characters */}
+      <div className="grid md:grid-cols-2 gap-6" key={activeId}>
         {/* Left Column */}
         <div>
-          <SkillAllocation character={character} onUpdate={fetchCharacters} />
-          <ClanManagement characterId={character.id} onUpdate={fetchCharacters} />
-          <AbilityShop character={character} onUpdate={fetchCharacters} />
+          <SkillAllocation character={character} onUpdate={refresh} />
+          <ClanManagement characterId={character.id} onUpdate={refresh} />
+          <AbilityShop character={character} onUpdate={refresh} />
         </div>
 
         {/* Right Column */}
         <div>
-          <BattleStats character={character} onUpdate={fetchCharacters} />
-          <AttackInterface character={character} onUpdate={fetchCharacters} />
-          <HitlistBrowser character={character} onUpdate={fetchCharacters} />
+          <BattleStats character={character} onUpdate={refresh} />
+          <AttackInterface character={character} onUpdate={refresh} />
+          <HitlistBrowser character={character} onUpdate={refresh} />
           <BattleFeed characterId={character.id} />
         </div>
       </div>

--- a/app/routes/shade.profile.tsx
+++ b/app/routes/shade.profile.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { apiClient } from "../lib/api";
 import { useAuth } from "../lib/AuthContext";
+import { useActiveCharacter } from "../lib/ActiveCharacterContext";
+import { ProfileComments } from "../components/ProfileComments";
 
 type GamerCharacter = {
   id: string;
@@ -109,6 +111,7 @@ function CharacterPanel({ char }: { char: GamerCharacter }) {
 export default function GamerProfilePage() {
   const { isAuthenticated, refreshUser } = useAuth();
   const [profile, setProfile] = useState<GamerProfile | null>(null);
+  const { activeId, setActive } = useActiveCharacter();
   const [characters, setCharacters] = useState<GamerCharacter[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -183,6 +186,20 @@ export default function GamerProfilePage() {
           <p className="text-shade-red-300 text-sm mt-1">
             {completedChars.length} character{completedChars.length === 1 ? "" : "s"} • Top level {topLevel || "—"} • {totalWins.toLocaleString()} total wins
           </p>
+          {completedChars.length > 0 && (
+            <div className="flex items-center gap-2 justify-center sm:justify-start mt-3">
+              <span className="text-xs text-shade-red-300">Playing as:</span>
+              <select
+                value={activeId ?? ''}
+                onChange={(e) => setActive(e.target.value)}
+                className="text-sm p-1.5 rounded bg-shade-black-600 neon-border text-shade-red-100"
+              >
+                {completedChars.map((ch) => (
+                  <option key={ch.id} value={ch.id}>{ch.gamertag} (Lv.{ch.level} {ch.class})</option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="flex gap-2 justify-center sm:justify-start mt-4">
             <button
               onClick={regenerateAvatar}
@@ -217,11 +234,23 @@ export default function GamerProfilePage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {completedChars.map((char) => (
-              <CharacterPanel key={char.id} char={char} />
+              <button
+                key={char.id}
+                onClick={() => setActive(char.id)}
+                className={`text-left rounded-xl transition-all ${char.id === activeId ? 'ring-2 ring-shade-red-500 shadow-[0_0_18px_rgba(255,42,42,0.35)]' : 'opacity-90 hover:opacity-100'}`}
+                title="Play as this character"
+              >
+                {char.id === activeId && (
+                  <div className="text-[10px] font-bold text-shade-red-300 px-2 pt-1">▶ PLAYING AS</div>
+                )}
+                <CharacterPanel char={char} />
+              </button>
             ))}
           </div>
         )}
       </div>
+
+      {profile?.username && <ProfileComments name={profile.username} />}
     </div>
   );
 }

--- a/app/routes/shade.u.$username.tsx
+++ b/app/routes/shade.u.$username.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { apiClient } from "../lib/api";
+import { ProfileComments } from "../components/ProfileComments";
 
 type PublicChar = {
   gamertag: string;
@@ -96,6 +97,8 @@ export default function PublicProfilePage() {
         )}
         <p className="text-xs text-shade-red-500/70 mt-4 text-center">Combat stats are private — only the owner can see them.</p>
       </div>
+
+      {username && <ProfileComments name={username} />}
     </div>
   );
 }

--- a/migrations/0014_active_character_and_profile_comments.sql
+++ b/migrations/0014_active_character_and_profile_comments.sql
@@ -1,0 +1,15 @@
+-- The character a user is currently "playing as" — everything they do in the
+-- game defaults to this character until they switch.
+ALTER TABLE users ADD COLUMN active_character_id TEXT;
+
+-- Comments left on a user's gamer profile (by anyone, including themselves).
+CREATE TABLE IF NOT EXISTS profile_comments (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    profile_user_id TEXT NOT NULL,   -- whose profile the comment is on
+    author_user_id TEXT NOT NULL,    -- who wrote it
+    body TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (profile_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_profile_comments_profile ON profile_comments(profile_user_id, created_at);

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -393,17 +393,29 @@ game.get('/leaderboard', async (c) => {
     return c.json({ data: rows.results || [] });
 });
 
+// Resolve a profile owner by account username OR a character gamertag, so
+// clicking any player name (which is usually a gamertag) lands on their profile.
+type ProfileUser = { id: string; username: string; shade_avatar_url: string | null; created_at: string };
+async function resolveProfileUser(db: D1Database, name: string): Promise<ProfileUser | null> {
+    const byName = await db
+        .prepare('SELECT id, username, shade_avatar_url, created_at FROM users WHERE username = ? COLLATE NOCASE')
+        .bind(name)
+        .first<ProfileUser>();
+    if (byName) return byName;
+    return db
+        .prepare(`SELECT u.id, u.username, u.shade_avatar_url, u.created_at
+                  FROM characters c JOIN users u ON u.id = c.user_id
+                  WHERE c.gamertag = ? COLLATE NOCASE`)
+        .bind(name)
+        .first<ProfileUser>();
+}
+
 // Public profile for any user: their characters with TROPHIES ONLY. Combat
 // stats (atk/def/spd/hp) are intentionally never exposed here — those are
 // private to the owner (see GET /game/profile for the owner's own full view).
-game.get('/profile/:username', async (c) => {
-    const username = c.req.param('username');
+game.get('/profile/:name', async (c) => {
     const db = c.env.DB;
-
-    const u = await db
-        .prepare('SELECT id, username, shade_avatar_url, created_at FROM users WHERE username = ? COLLATE NOCASE')
-        .bind(username)
-        .first<{ id: string; username: string; shade_avatar_url: string | null; created_at: string }>();
+    const u = await resolveProfileUser(db, c.req.param('name'));
     if (!u) {
         return c.json({ error: 'User not found' }, 404);
     }
@@ -424,6 +436,73 @@ game.get('/profile/:username', async (c) => {
             characters: characters.results || [],
         },
     });
+});
+
+// List comments on a profile (anyone can read).
+game.get('/profile/:name/comments', async (c) => {
+    const db = c.env.DB;
+    const u = await resolveProfileUser(db, c.req.param('name'));
+    if (!u) return c.json({ error: 'User not found' }, 404);
+
+    const comments = await db.prepare(`
+        SELECT pc.id, pc.body, pc.created_at, au.username AS author, pc.author_user_id
+        FROM profile_comments pc
+        JOIN users au ON au.id = pc.author_user_id
+        WHERE pc.profile_user_id = ?
+        ORDER BY pc.created_at DESC
+        LIMIT 100
+    `).bind(u.id).all();
+
+    return c.json({ data: comments.results || [] });
+});
+
+// Post a comment on a profile (including your own).
+game.post('/profile/:name/comments', zValidator('json', z.object({ body: z.string().min(1).max(500) })), async (c) => {
+    const user = c.get('user');
+    const db = c.env.DB;
+    const u = await resolveProfileUser(db, c.req.param('name'));
+    if (!u) return c.json({ error: 'User not found' }, 404);
+
+    const { body } = c.req.valid('json');
+    const id = crypto.randomUUID();
+    await db.prepare('INSERT INTO profile_comments (id, profile_user_id, author_user_id, body) VALUES (?, ?, ?, ?)')
+        .bind(id, u.id, user.id, body)
+        .run();
+
+    return c.json({ data: { id, body, author: user.username, author_user_id: user.id, created_at: new Date().toISOString() } }, 201);
+});
+
+// Delete a comment (the author, or the profile owner, may remove it).
+game.delete('/comments/:id', async (c) => {
+    const user = c.get('user');
+    const db = c.env.DB;
+    const id = c.req.param('id');
+
+    const row = await db.prepare('SELECT author_user_id, profile_user_id FROM profile_comments WHERE id = ?')
+        .bind(id)
+        .first<{ author_user_id: string; profile_user_id: string }>();
+    if (!row) return c.json({ error: 'Comment not found' }, 404);
+    if (row.author_user_id !== user.id && row.profile_user_id !== user.id) {
+        return c.json({ error: 'Not allowed' }, 403);
+    }
+
+    await db.prepare('DELETE FROM profile_comments WHERE id = ?').bind(id).run();
+    return c.json({ message: 'Comment deleted' });
+});
+
+// Set the character the user is "playing as" (defaults all game actions to it).
+game.post('/active-character', zValidator('json', z.object({ characterId: z.string().uuid() })), async (c) => {
+    const user = c.get('user');
+    const db = c.env.DB;
+    const { characterId } = c.req.valid('json');
+
+    const owned = await db.prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+        .bind(characterId, user.id)
+        .first();
+    if (!owned) return c.json({ error: 'Character not found or does not belong to you.' }, 404);
+
+    await db.prepare('UPDATE users SET active_character_id = ? WHERE id = ?').bind(characterId, user.id).run();
+    return c.json({ message: 'Active character updated', active_character_id: characterId });
 });
 
 // Get all user's characters

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -46,8 +46,8 @@ const storm8 = new Hono<App>();
 // All routes require authentication
 storm8.use('*', authMiddleware);
 
-// Resolve which of the user's characters is acting. The Battle tab passes
-// ?character_id=...; we verify ownership and otherwise fall back to slot 1.
+// Resolve which of the user's characters is acting. An explicit ?character_id=
+// wins; otherwise we use the user's chosen active character; otherwise slot 1.
 // Returns null if a character_id was provided that the user doesn't own.
 async function actingCharId(db: D1Database, c: any, userId: string): Promise<string | null> {
   const requested = c.req.query('character_id');
@@ -57,6 +57,18 @@ async function actingCharId(db: D1Database, c: any, userId: string): Promise<str
       .bind(requested, userId)
       .first<{ id: string }>();
     return owned ? owned.id : null;
+  }
+  // Default to the user's active ("playing as") character if it's still theirs.
+  const u = await db
+    .prepare('SELECT active_character_id FROM users WHERE id = ?')
+    .bind(userId)
+    .first<{ active_character_id: string | null }>();
+  if (u?.active_character_id) {
+    const ok = await db
+      .prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+      .bind(u.active_character_id, userId)
+      .first<{ id: string }>();
+    if (ok) return ok.id;
   }
   const first = await db
     .prepare('SELECT id FROM characters WHERE user_id = ? ORDER BY slot_number LIMIT 1')

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -53,9 +53,9 @@ users.get('/me', authMiddleware, async (c) => {
   const db = c.env.DB;
 
   const character = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(user.id).first<{id: string}>();
-  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password, shade_avatar_url FROM users WHERE id = ?').bind(user.id).first<{ has_password: number; shade_avatar_url: string | null }>();
+  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password, shade_avatar_url, active_character_id FROM users WHERE id = ?').bind(user.id).first<{ has_password: number; shade_avatar_url: string | null; active_character_id: string | null }>();
 
-  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password, shade_avatar_url: account?.shade_avatar_url ?? null } });
+  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password, shade_avatar_url: account?.shade_avatar_url ?? null, active_character_id: account?.active_character_id ?? null } });
 });
 
 // PUT /api/users/me - Update the current authenticated user's profile


### PR DESCRIPTION
## Active character ("playing as")
- New `users.active_character_id` (migration 0014) + `POST /game/active-character`.
- The storm8 `actingCharId` resolver and game endpoints **default to it**; `/users/me` returns it.
- New `ActiveCharacterProvider`: the **Battle tab, Dashboard, and Profile** all share one **"Playing as"** selection that persists across pages and server-side, so everything you do is for that character until you switch.

## Click a player's name → their profile
- `/game/profile/:name` now resolves by **username OR character gamertag**.
- **Leaderboard, Find Players, and the battle feed** link names to `/shade/u/:name`.

## Profile comments
- New `profile_comments` table; `GET`/`POST /game/profile/:name/comments` and `DELETE /game/comments/:id` (author or profile owner can delete).
- A `ProfileComments` wall on both the **public** profile and your **own** profile.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅ • migration 0014 applied to remote.
- Post-deploy: set active char and confirm attacks default to it; open a profile by gamertag; post/list/delete a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)