### PR TITLE
Defense character (challenged when you're attacked)

### DIFF
--- a/app/lib/AuthContext.tsx
+++ b/app/lib/AuthContext.tsx
@@ -13,6 +13,7 @@ interface User {
   has_password?: boolean;
   shade_avatar_url?: string | null;
   active_character_id?: string | null;
+  defense_character_id?: string | null;
 }
 
 interface AuthContextType {

--- a/app/routes/game.dashboard.tsx
+++ b/app/routes/game.dashboard.tsx
@@ -436,8 +436,8 @@ function PurchaseSlotModal({
 }
 
 export default function GameDashboardPage() {
-  const { user } = useAuth();
-  const { activeId, setActive } = useActiveCharacter();
+  const { user, refreshUser } = useAuth();
+  const { activeId, setActive, characters: myChars } = useActiveCharacter();
   const [slotInfo, setSlotInfo] = useState<SlotInfo | null>(null);
   const [character, setCharacter] = useState<Character | null>(null);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
@@ -544,6 +544,16 @@ export default function GameDashboardPage() {
     fetchSlotInfo();
     if (selectedCharacterId) {
       fetchCharacter(selectedCharacterId);
+    }
+  };
+
+  const handleSetDefense = async (charId: string) => {
+    if (!charId) return;
+    try {
+      await apiClient.post('/game/defense-character', { characterId: charId });
+      await refreshUser();
+    } catch (err: any) {
+      setError(err.message || 'Failed to set defender');
     }
   };
 
@@ -659,6 +669,24 @@ export default function GameDashboardPage() {
           Story Mode
         </button>
       </div>
+
+      {/* Defense character: who gets challenged when someone attacks you */}
+      {myChars.length > 0 && (
+        <div className="mb-4 p-3 rounded-xl bg-gradient-to-r from-sky-950/40 to-shade-black-900 border border-sky-800/40 flex flex-col sm:flex-row sm:items-center gap-2">
+          <span className="text-sm text-sky-200">🛡️ Defending character:</span>
+          <select
+            value={user?.defense_character_id ?? ''}
+            onChange={(e) => handleSetDefense(e.target.value)}
+            className="p-2 rounded bg-shade-black-700 border border-sky-700/50 text-shade-red-100 text-sm"
+          >
+            <option value="" disabled>Choose a defender…</option>
+            {myChars.map((ch: any) => (
+              <option key={ch.id} value={ch.id}>{ch.gamertag} (Lv.{ch.level} {ch.class})</option>
+            ))}
+          </select>
+          <span className="text-xs text-sky-300/70">This character is challenged when another player attacks you.</span>
+        </div>
+      )}
 
       {character && character.first_game_access_completed ? (
         <>

--- a/migrations/0015_defense_character.sql
+++ b/migrations/0015_defense_character.sql
@@ -1,0 +1,3 @@
+-- The character that defends when this user is attacked. If set, any attack
+-- aimed at one of the user's characters is challenged against this one instead.
+ALTER TABLE users ADD COLUMN defense_character_id TEXT;

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -505,6 +505,21 @@ game.post('/active-character', zValidator('json', z.object({ characterId: z.stri
     return c.json({ message: 'Active character updated', active_character_id: characterId });
 });
 
+// Set the character that defends when this user is attacked.
+game.post('/defense-character', zValidator('json', z.object({ characterId: z.string().uuid() })), async (c) => {
+    const user = c.get('user');
+    const db = c.env.DB;
+    const { characterId } = c.req.valid('json');
+
+    const owned = await db.prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+        .bind(characterId, user.id)
+        .first();
+    if (!owned) return c.json({ error: 'Character not found or does not belong to you.' }, 404);
+
+    await db.prepare('UPDATE users SET defense_character_id = ? WHERE id = ?').bind(characterId, user.id).run();
+    return c.json({ message: 'Defense character updated', defense_character_id: characterId });
+});
+
 // Get all user's characters
 game.get('/my-characters', async (c) => {
     const user = c.get('user');

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -507,6 +507,28 @@ function bumpTrophies(
     .bind(characterId, w, l, k, d);
 }
 
+// If the target's owner has designated a defense character, the attack is
+// challenged against THAT character instead of whichever one was targeted.
+async function applyDefenseCharacter(db: D1Database, targetId: string): Promise<string> {
+  const owner = await db
+    .prepare('SELECT user_id FROM characters WHERE id = ?')
+    .bind(targetId)
+    .first<{ user_id: string }>();
+  if (!owner) return targetId;
+  const u = await db
+    .prepare('SELECT defense_character_id FROM users WHERE id = ?')
+    .bind(owner.user_id)
+    .first<{ defense_character_id: string | null }>();
+  if (u?.defense_character_id && u.defense_character_id !== targetId) {
+    const dc = await db
+      .prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+      .bind(u.defense_character_id, owner.user_id)
+      .first<{ id: string }>();
+    if (dc) return dc.id;
+  }
+  return targetId;
+}
+
 // Resolve a target character by id or (case-insensitive) gamertag/name.
 async function resolveTargetId(db: D1Database, opts: { id?: string; gamertag?: string }): Promise<string | null> {
   if (opts.id) return opts.id;
@@ -547,11 +569,13 @@ storm8.post('/attack', zValidator('json', attackPlayerSchema), async (c) => {
     return c.json({ error: 'Character not found' }, 404);
   }
 
-  // Resolve the target by id or name.
-  const defenderId = await resolveTargetId(db, { id: defender_character_id, gamertag: defender_gamertag });
-  if (!defenderId) {
+  // Resolve the target by id or name, then redirect to the owner's designated
+  // defense character (if any).
+  const targetedId = await resolveTargetId(db, { id: defender_character_id, gamertag: defender_gamertag });
+  if (!targetedId) {
     return c.json({ error: `No character found named "${defender_gamertag ?? ''}"` }, 404);
   }
+  const defenderId = await applyDefenseCharacter(db, targetedId);
 
   if (attackerChar.id === defenderId) {
     return c.json({ error: 'Cannot attack yourself' }, 400);

--- a/workers/src/api/users.ts
+++ b/workers/src/api/users.ts
@@ -53,9 +53,9 @@ users.get('/me', authMiddleware, async (c) => {
   const db = c.env.DB;
 
   const character = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(user.id).first<{id: string}>();
-  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password, shade_avatar_url, active_character_id FROM users WHERE id = ?').bind(user.id).first<{ has_password: number; shade_avatar_url: string | null; active_character_id: string | null }>();
+  const account = await db.prepare('SELECT (password_hash IS NOT NULL) AS has_password, shade_avatar_url, active_character_id, defense_character_id FROM users WHERE id = ?').bind(user.id).first<{ has_password: number; shade_avatar_url: string | null; active_character_id: string | null; defense_character_id: string | null }>();
 
-  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password, shade_avatar_url: account?.shade_avatar_url ?? null, active_character_id: account?.active_character_id ?? null } });
+  return c.json({ data: { ...user, characterId: character?.id, has_password: !!account?.has_password, shade_avatar_url: account?.shade_avatar_url ?? null, active_character_id: account?.active_character_id ?? null, defense_character_id: account?.defense_character_id ?? null } });
 });
 
 // PUT /api/users/me - Update the current authenticated user's profile


### PR DESCRIPTION
Lets a user designate which of their characters defends when another player attacks them.

- New `users.defense_character_id` (migration 0015, applied) + `POST /game/defense-character`.
- `/storm8/attack` redirects the defense to the target owner's chosen defense character (if set) — so that character is challenged no matter which of their characters was aimed at. `/users/me` exposes it.
- **Dashboard:** a 🛡️ 'Defending character' selector.

npm run build ✅ • typecheck ✅ • migration applied to remote ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)