### PR TITLE
Show defender badge on profiles

### DIFF
--- a/app/routes/shade.profile.tsx
+++ b/app/routes/shade.profile.tsx
@@ -109,7 +109,7 @@ function CharacterPanel({ char }: { char: GamerCharacter }) {
 }
 
 export default function GamerProfilePage() {
-  const { isAuthenticated, refreshUser } = useAuth();
+  const { isAuthenticated, refreshUser, user } = useAuth();
   const [profile, setProfile] = useState<GamerProfile | null>(null);
   const { activeId, setActive } = useActiveCharacter();
   const [characters, setCharacters] = useState<GamerCharacter[]>([]);
@@ -186,6 +186,12 @@ export default function GamerProfilePage() {
           <p className="text-shade-red-300 text-sm mt-1">
             {completedChars.length} character{completedChars.length === 1 ? "" : "s"} • Top level {topLevel || "—"} • {totalWins.toLocaleString()} total wins
           </p>
+          {(() => {
+            const defender = characters.find((c) => c.id === user?.defense_character_id);
+            return defender ? (
+              <p className="text-sm text-sky-300 mt-1">🛡️ Defender: <span className="font-bold">{defender.gamertag}</span></p>
+            ) : null;
+          })()}
           {completedChars.length > 0 && (
             <div className="flex items-center gap-2 justify-center sm:justify-start mt-3">
               <span className="text-xs text-shade-red-300">Playing as:</span>

--- a/app/routes/shade.u.$username.tsx
+++ b/app/routes/shade.u.$username.tsx
@@ -17,6 +17,7 @@ type PublicProfile = {
   username: string;
   shade_avatar_url: string | null;
   created_at: string | null;
+  defender_gamertag: string | null;
 };
 
 // Public profile: trophies only. Combat stats are private to the owner.
@@ -59,6 +60,9 @@ export default function PublicProfilePage() {
           <p className="text-shade-red-300 text-sm mt-1">
             {characters.length} character{characters.length === 1 ? "" : "s"} • {totalWins.toLocaleString()} wins • {totalKills.toLocaleString()} kills
           </p>
+          {profile.defender_gamertag && (
+            <p className="text-sm text-sky-300 mt-2">🛡️ Defender: <span className="font-bold">{profile.defender_gamertag}</span></p>
+          )}
           <Link to="/shade/leaderboard" className="text-xs text-shade-red-400 hover:text-shade-red-200 mt-3 inline-block">← Leaderboard</Link>
         </div>
       </div>

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -430,9 +430,21 @@ game.get('/profile/:name', async (c) => {
         ORDER BY c.slot_number
     `).bind(u.id).all();
 
+    // Who answers when this player is attacked (so opponents know who they'll face).
+    const defender = await db.prepare(`
+        SELECT c.gamertag FROM users usr
+        JOIN characters c ON c.id = usr.defense_character_id
+        WHERE usr.id = ?
+    `).bind(u.id).first<{ gamertag: string }>();
+
     return c.json({
         data: {
-            profile: { username: u.username, shade_avatar_url: u.shade_avatar_url, created_at: u.created_at },
+            profile: {
+                username: u.username,
+                shade_avatar_url: u.shade_avatar_url,
+                created_at: u.created_at,
+                defender_gamertag: defender?.gamertag ?? null,
+            },
             characters: characters.results || [],
         },
     });


### PR DESCRIPTION
The public profile endpoint now returns `defender_gamertag`, and both the **public** (`/shade/u/:name`) and **own** (`/shade/profile`) profiles show a **🛡️ Defender: <name>** badge — so opponents see who they'll face when they attack.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)