### PR TITLE
Passive health regen + live stamina/energy + cron regen

### DIFF
--- a/migrations/0016_health_regen.sql
+++ b/migrations/0016_health_regen.sql
@@ -1,0 +1,4 @@
+-- Track when each character last regenerated health (for passive health regen).
+-- (SQLite disallows CURRENT_TIMESTAMP as an ADD COLUMN default, so backfill it.)
+ALTER TABLE characters ADD COLUMN last_health_regen TIMESTAMP;
+UPDATE characters SET last_health_regen = CURRENT_TIMESTAMP WHERE last_health_regen IS NULL;

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -7,6 +7,7 @@ import type { AuthenticatedUser } from './middleware/auth';
 import { firstAccessSchema, customizeCharacterSchema } from '../shared/schemas/game';
 import { MAX_LEVEL, getTotalStatPointsForLevel, getAllLevelAchievementsUpTo, getXpForLevel } from '../core/leveling';
 import { BASE_STATS, CHARACTER_CLASSES } from '../core/classes';
+import { regenUserCharacters } from '../core/regen';
 
 type App = {
   Bindings: Bindings;
@@ -537,6 +538,9 @@ game.get('/my-characters', async (c) => {
     const user = c.get('user');
     const db = c.env.DB;
 
+    // Bring health/stamina/energy current so the UI shows live values.
+    await regenUserCharacters(db, user.id);
+
     const characters = await db.prepare(`
         SELECT c.*, t.wins, t.losses, t.kills, t.deaths
         FROM characters c
@@ -553,6 +557,8 @@ game.get('/my-characters', async (c) => {
 game.get('/profile', async (c) => {
     const user = c.get('user');
     const db = c.env.DB;
+
+    await regenUserCharacters(db, user.id);
 
     const profile = await db
         .prepare('SELECT id, username, avatar_url, shade_avatar_url, created_at FROM users WHERE id = ?')

--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -25,7 +25,6 @@ import {
   calculateUsableClanMembers,
   getClanBracket,
   areInSameBracket,
-  calculateRegeneration,
   canAttackByLevel,
   getAttackXpMultiplier,
   getBaseAttackXp,
@@ -33,6 +32,7 @@ import {
   type CharacterBattleStats,
 } from '../core/storm8-battle-engine';
 import { checkForLevelUp } from '../core/leveling';
+import { applyResourceRegeneration } from '../core/regen';
 
 type App = {
   Bindings: Bindings;
@@ -334,61 +334,8 @@ storm8.get('/abilities/owned', async (c) => {
 // RESOURCE REGENERATION HELPER
 // ============================================================================
 
-async function applyResourceRegeneration(db: D1Database, characterId: string): Promise<void> {
-  const char = await db
-    .prepare(`
-      SELECT
-        current_energy, max_energy, last_energy_regen,
-        current_stamina, max_stamina, last_stamina_regen
-      FROM characters WHERE id = ?
-    `)
-    .bind(characterId)
-    .first<{
-      current_energy: number;
-      max_energy: number;
-      last_energy_regen: string;
-      current_stamina: number;
-      max_stamina: number;
-      last_stamina_regen: string;
-    }>();
-
-  if (!char) return;
-
-  // Energy: 1 point per 5 minutes
-  const energyRegen = calculateRegeneration(
-    char.last_energy_regen,
-    char.current_energy,
-    char.max_energy,
-    5
-  );
-
-  // Stamina: 1 point per 3 minutes
-  const staminaRegen = calculateRegeneration(
-    char.last_stamina_regen,
-    char.current_stamina,
-    char.max_stamina,
-    3
-  );
-
-  await db
-    .prepare(`
-      UPDATE characters
-      SET
-        current_energy = ?,
-        last_energy_regen = ?,
-        current_stamina = ?,
-        last_stamina_regen = ?
-      WHERE id = ?
-    `)
-    .bind(
-      energyRegen.newAmount,
-      energyRegen.newTimestamp,
-      staminaRegen.newAmount,
-      staminaRegen.newTimestamp,
-      characterId
-    )
-    .run();
-}
+// applyResourceRegeneration now lives in core/regen.ts (energy + stamina + health),
+// shared with the cron and the read endpoints.
 
 // ============================================================================
 // BATTLE STATS HELPER

--- a/workers/src/core/cron.ts
+++ b/workers/src/core/cron.ts
@@ -1,5 +1,6 @@
 import type { Bindings } from "../bindings";
 import { checkForLevelUp } from "./leveling";
+import { applyResourceRegeneration } from "./regen";
 
 interface CharacterWithLedger {
     id: string;
@@ -72,6 +73,13 @@ export async function handleScheduled(env: Bindings) {
 
                 await db.batch(statements);
             }
+        }
+
+        // Tick health/stamina/energy regeneration for every character so it
+        // advances even while players are offline.
+        console.log('Cron job: regenerating resources');
+        for (const char of charactersToUpdate.results) {
+            await applyResourceRegeneration(db, char.id);
         }
     } catch (e) {
         console.error('Cron job error:', e);

--- a/workers/src/core/regen.ts
+++ b/workers/src/core/regen.ts
@@ -1,0 +1,78 @@
+import { calculateRegeneration } from './storm8-battle-engine';
+
+// Health regenerates 2% of max per minute (≈50 min from 0 to full), so a
+// defeated character recovers over time without needing the hospital.
+const HEALTH_REGEN_PCT_PER_MIN = 0.02;
+
+type RegenRow = {
+  current_energy: number;
+  max_energy: number;
+  last_energy_regen: string | null;
+  current_stamina: number;
+  max_stamina: number;
+  last_stamina_regen: string | null;
+  current_health: number;
+  max_health: number;
+  last_health_regen: string | null;
+};
+
+// Bring a single character's time-based resources (energy, stamina, health)
+// up to date. Lazy: safe to call on read or from the cron.
+export async function applyResourceRegeneration(db: D1Database, characterId: string): Promise<void> {
+  const char = await db
+    .prepare(`
+      SELECT
+        current_energy, max_energy, last_energy_regen,
+        current_stamina, max_stamina, last_stamina_regen,
+        current_health, max_health, last_health_regen
+      FROM characters WHERE id = ?
+    `)
+    .bind(characterId)
+    .first<RegenRow>();
+  if (!char) return;
+
+  const nowIso = new Date().toISOString();
+
+  // Energy: +1 per 5 min. Stamina: +1 per 3 min.
+  const energyRegen = calculateRegeneration(char.last_energy_regen || nowIso, char.current_energy, char.max_energy, 5);
+  const staminaRegen = calculateRegeneration(char.last_stamina_regen || nowIso, char.current_stamina, char.max_stamina, 3);
+
+  // Health: percentage of max per minute (works from 0, i.e. revives the defeated).
+  let newHealth = char.current_health;
+  let newHealthTs = char.last_health_regen || nowIso;
+  if (char.current_health >= char.max_health) {
+    newHealth = char.max_health;
+    newHealthTs = nowIso; // keep fresh while at full so it doesn't over-accrue later
+  } else {
+    const minutes = (Date.now() - new Date(char.last_health_regen || nowIso).getTime()) / 60000;
+    const regen = Math.floor(char.max_health * HEALTH_REGEN_PCT_PER_MIN * minutes);
+    if (regen > 0) {
+      newHealth = Math.min(char.max_health, char.current_health + regen);
+      newHealthTs = nowIso;
+    }
+  }
+
+  await db
+    .prepare(`
+      UPDATE characters SET
+        current_energy = ?, last_energy_regen = ?,
+        current_stamina = ?, last_stamina_regen = ?,
+        current_health = ?, last_health_regen = ?
+      WHERE id = ?
+    `)
+    .bind(
+      energyRegen.newAmount, energyRegen.newTimestamp,
+      staminaRegen.newAmount, staminaRegen.newTimestamp,
+      newHealth, newHealthTs,
+      characterId,
+    )
+    .run();
+}
+
+// Regenerate all of a user's characters (used on read so displayed values are live).
+export async function regenUserCharacters(db: D1Database, userId: string): Promise<void> {
+  const rows = await db.prepare('SELECT id FROM characters WHERE user_id = ?').bind(userId).all<{ id: string }>();
+  for (const r of rows.results || []) {
+    await applyResourceRegeneration(db, r.id);
+  }
+}


### PR DESCRIPTION
Per request, all three:

- **Passive health regen** — `core/regen.ts` now regenerates **health at 2%/min** (works from 0, so defeated characters recover without the hospital), plus the existing stamina (1/3min) and energy (1/5min). Migration 0016 adds `last_health_regen`.
- **Live stamina/energy/health** — regen is now applied on read (`/game/my-characters`, own `/game/profile`), so the Battle tab/Dashboard show current values, not stale-until-you-attack.
- **Cron ticks for everyone** — the every-5-minute scheduled job advances regen for all characters, so it accrues while offline.

npm run build ✅ • typecheck ✅ • migration 0016 applied to remote ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)