### PR TITLE
Autonomous bot attacks + game-expert AI assistant

### DIFF
--- a/workers/src/api/storm8-battles.ts
+++ b/workers/src/api/storm8-battles.ts
@@ -29,10 +29,10 @@ import {
   getAttackXpMultiplier,
   getBaseAttackXp,
   getLevelBracket,
-  type CharacterBattleStats,
 } from '../core/storm8-battle-engine';
 import { checkForLevelUp } from '../core/leveling';
 import { applyResourceRegeneration } from '../core/regen';
+import { getCharacterBattleStats, bumpTrophies } from '../core/battle';
 
 type App = {
   Bindings: Bindings;
@@ -341,118 +341,7 @@ storm8.get('/abilities/owned', async (c) => {
 // BATTLE STATS HELPER
 // ============================================================================
 
-async function getCharacterBattleStats(db: D1Database, characterId: string): Promise<CharacterBattleStats | null> {
-  const char = await db
-    .prepare(`
-      SELECT
-        c.id, c.level, c.class,
-        c.atk, c.def, c.spd,
-        c.attack_skill_points, c.defense_skill_points, c.health_skill_points,
-        c.current_health, c.max_health, c.current_stamina,
-        c.unbanked_currency, c.banked_currency
-      FROM characters c
-      WHERE c.id = ?
-    `)
-    .bind(characterId)
-    .first<{
-      id: string;
-      level: number;
-      class: string;
-      atk: number;
-      def: number;
-      spd: number;
-      attack_skill_points: number;
-      defense_skill_points: number;
-      health_skill_points: number;
-      current_health: number;
-      max_health: number;
-      current_stamina: number;
-      unbanked_currency: number;
-      banked_currency: number;
-    }>();
-
-  if (!char) return null;
-
-  // Get total clan members
-  const clanCount = await db
-    .prepare('SELECT COUNT(*) as total FROM clan_members WHERE character_id = ?')
-    .bind(characterId)
-    .first<{ total: number }>();
-
-  const usableClanMembers = calculateUsableClanMembers(char.level, clanCount?.total || 0);
-
-  // Best attack ability per category (SQLite has no DISTINCT ON — use GROUP BY).
-  const attackAbilities = await db
-    .prepare(`
-      SELECT MAX(a.attack_value) AS attack_value
-      FROM character_abilities ca
-      JOIN abilities a ON ca.ability_id = a.id
-      WHERE ca.character_id = ?
-      GROUP BY a.category
-    `)
-    .bind(characterId)
-    .all();
-
-  // Best defense ability per category.
-  const defenseAbilities = await db
-    .prepare(`
-      SELECT MAX(a.defense_value) AS defense_value
-      FROM character_abilities ca
-      JOIN abilities a ON ca.ability_id = a.id
-      WHERE ca.character_id = ?
-      GROUP BY a.category
-    `)
-    .bind(characterId)
-    .all();
-
-  const equipment_attack = (attackAbilities.results || []).reduce((sum: number, a: any) => sum + (a.attack_value || 0), 0);
-  const equipment_defense = (defenseAbilities.results || []).reduce((sum: number, a: any) => sum + (a.defense_value || 0), 0);
-
-  return {
-    id: char.id,
-    level: char.level,
-    char_class: char.class,
-    attack: char.atk || 0,
-    defense: char.def || 0,
-    speed: char.spd || 0,
-    attack_skill_points: char.attack_skill_points,
-    defense_skill_points: char.defense_skill_points,
-    health_skill_points: char.health_skill_points,
-    current_health: char.current_health,
-    max_health: char.max_health,
-    current_stamina: char.current_stamina,
-    equipment_attack,
-    equipment_defense,
-    usable_clan_members: usableClanMembers,
-    unbanked_currency: char.unbanked_currency,
-    banked_currency: char.banked_currency,
-  };
-}
-
-// Increment a character's trophy counters. Uses an upsert so it works even if
-// the character has no trophies row yet (older characters were missing one,
-// which silently dropped all of their wins/losses/kills/deaths).
-function bumpTrophies(
-  db: D1Database,
-  characterId: string,
-  delta: { wins?: number; losses?: number; kills?: number; deaths?: number },
-) {
-  const w = delta.wins ?? 0;
-  const l = delta.losses ?? 0;
-  const k = delta.kills ?? 0;
-  const d = delta.deaths ?? 0;
-  return db
-    .prepare(`
-      INSERT INTO trophies (character_id, wins, losses, kills, deaths)
-      VALUES (?, ?, ?, ?, ?)
-      ON CONFLICT(character_id) DO UPDATE SET
-        wins = wins + excluded.wins,
-        losses = losses + excluded.losses,
-        kills = kills + excluded.kills,
-        deaths = deaths + excluded.deaths
-    `)
-    .bind(characterId, w, l, k, d);
-}
+// getCharacterBattleStats and bumpTrophies now live in core/battle.ts.
 
 // If the target's owner has designated a defense character, the attack is
 // challenged against THAT character instead of whichever one was targeted.

--- a/workers/src/api/voice.ts
+++ b/workers/src/api/voice.ts
@@ -34,11 +34,47 @@ const voice = new Hono<App>();
 // Wit.ai API version
 const WIT_API_VERSION = '20230215';
 
-// System prompt for the voice assistant. Personalized with the account's
-// username so the assistant knows who it's speaking with.
+// System prompt for the voice assistant — an in-game expert coach for the
+// .shade RPG that teaches strategy, builds, and point placement.
 function buildSystemPrompt(username?: string): string {
-  const base = `You are a helpful and friendly voice assistant for the .shade platform. Keep your responses concise and conversational since they will be spoken aloud. Avoid using markdown, code blocks, or formatting that doesn't work well in speech. Respond naturally as if having a spoken conversation.`;
-  return username ? `${base} You are speaking with ${username}; address them by name when it feels natural.` : base;
+  const base = `You are the .shade game guide — a friendly, expert coach for the .shade RPG. You teach players how the game works, recommend builds, and advise on stat-point placement. Keep responses concise and conversational (they are spoken aloud): no markdown or code blocks.
+
+GAME KNOWLEDGE (authoritative — use this, don't invent mechanics):
+
+Classes and base stats (HP / ATK / DEF / SPD):
+- Phoenix: 10000 / 1000 / 500 / 100 — balanced, attack-leaning.
+- Dark Phoenix (dphoenix): 10000 / 1750 / 375 / 150 — highest base attack, glass cannon.
+- Dragon: 10000 / 750 / 1100 / 175 — tanky; dragons also gain bonus attack power from their DEF + SPD.
+- Dark Dragon (ddragon): 10000 / 1000 / 1000 / 75 — balanced bruiser (also gets the dragon DEF+SPD attack bonus).
+- Kies: 15000 / 750 / 750 / 225 — highest base HP and speed.
+
+Stat-point allocation (one point each, from the unspent pool you earn by leveling — about 5 per level, plus 5 extra every 5th level):
+- HP: +100 max health per point. Health is your battle pool.
+- SPD: +2 speed per point. Speed is powerful (see battles).
+- ATK: +1% of your class's BASE attack per point. So 100 ATK points = +100% = double your base attack. Higher-base-attack classes get more per point.
+- DEF: +1% of your class's BASE defense per point.
+- MP is unused — don't spend points there.
+- Tip: because ATK/DEF scale off BASE, the class you start with strongly shapes which stats are efficient.
+
+Battle mechanics:
+- Speed decides initiative: the faster fighter strikes FIRST, and lands multiple hits before the slower one can respond — roughly (faster speed / slower speed) hits, capped at 5. The slower fighter gets a single counterattack only if still alive. So a big speed advantage can let you hit 2-5 times and even kill before they swing.
+- Damage uses mitigation: defense reduces damage but never to zero, so every landed hit chips health. Roughly attack^2 / (attack + defense).
+- Dragons (dragon, ddragon) add their DEF and SPD to their attack power — a tanky dragon still hits hard.
+- Killing: bringing a target to 0 HP earns the attacker a kill and win; the loser gets a death and loss and stays defeated (unattackable) until healed.
+- Defense character: you can pick a "defending character" on the dashboard; when someone attacks you, that character answers. Your "active/playing-as" character is who acts when you attack or build.
+
+Recovery: health and stamina regenerate over time (health ~2% of max per minute; stamina 1 per 3 minutes). The Hospital (on the dashboard) heals to full instantly for currency (10 per HP). Attacks cost 1 stamina.
+
+Other systems: a leaderboard (by level, wins, kills); a Hitlist where players post bounties to have others killed; clans (members multiply equipment power in battle); an Ability Shop (equipment that adds ATK/DEF — buy what your level allows). You also fight bot opponents across levels 1-275.
+
+Build strategy you can recommend:
+- Speed build: pump SPD to strike first and multi-hit — great for bursting down slower targets before they retaliate. Pair with enough ATK to make hits hurt.
+- Glass cannon: Dark Phoenix + heavy ATK; fast kills but fragile.
+- Tank/bruiser: Dragon with DEF + SPD (DEF feeds attack for dragons) + HP to survive and grind.
+- Always keep some HP so a single fast attacker can't one-shot you.
+
+Be specific and practical. If asked "where should I put points," ask about their class and goal, then give a concrete split.`;
+  return username ? `${base}\n\nYou are speaking with ${username}; address them by name when natural.` : base;
 }
 
 // Per-user KV key for the saved voice conversation.

--- a/workers/src/core/battle.ts
+++ b/workers/src/core/battle.ts
@@ -1,0 +1,99 @@
+import { calculateUsableClanMembers, type CharacterBattleStats } from './storm8-battle-engine';
+
+// Build a character's full battle stats (core + skill points + equipment + clan).
+// Shared by the live attack endpoints and the autonomous bot loop.
+export async function getCharacterBattleStats(db: D1Database, characterId: string): Promise<CharacterBattleStats | null> {
+  const char = await db
+    .prepare(`
+      SELECT
+        c.id, c.level, c.class,
+        c.atk, c.def, c.spd,
+        c.attack_skill_points, c.defense_skill_points, c.health_skill_points,
+        c.current_health, c.max_health, c.current_stamina,
+        c.unbanked_currency, c.banked_currency
+      FROM characters c
+      WHERE c.id = ?
+    `)
+    .bind(characterId)
+    .first<{
+      id: string;
+      level: number;
+      class: string;
+      atk: number;
+      def: number;
+      spd: number;
+      attack_skill_points: number;
+      defense_skill_points: number;
+      health_skill_points: number;
+      current_health: number;
+      max_health: number;
+      current_stamina: number;
+      unbanked_currency: number;
+      banked_currency: number;
+    }>();
+
+  if (!char) return null;
+
+  const clanCount = await db
+    .prepare('SELECT COUNT(*) as total FROM clan_members WHERE character_id = ?')
+    .bind(characterId)
+    .first<{ total: number }>();
+
+  const usableClanMembers = calculateUsableClanMembers(char.level, clanCount?.total || 0);
+
+  // Best attack/defense ability per category (SQLite has no DISTINCT ON — GROUP BY).
+  const attackAbilities = await db
+    .prepare(`SELECT MAX(a.attack_value) AS attack_value FROM character_abilities ca JOIN abilities a ON ca.ability_id = a.id WHERE ca.character_id = ? GROUP BY a.category`)
+    .bind(characterId)
+    .all();
+  const defenseAbilities = await db
+    .prepare(`SELECT MAX(a.defense_value) AS defense_value FROM character_abilities ca JOIN abilities a ON ca.ability_id = a.id WHERE ca.character_id = ? GROUP BY a.category`)
+    .bind(characterId)
+    .all();
+
+  const equipment_attack = (attackAbilities.results || []).reduce((sum: number, a: any) => sum + (a.attack_value || 0), 0);
+  const equipment_defense = (defenseAbilities.results || []).reduce((sum: number, a: any) => sum + (a.defense_value || 0), 0);
+
+  return {
+    id: char.id,
+    level: char.level,
+    char_class: char.class,
+    attack: char.atk || 0,
+    defense: char.def || 0,
+    speed: char.spd || 0,
+    attack_skill_points: char.attack_skill_points,
+    defense_skill_points: char.defense_skill_points,
+    health_skill_points: char.health_skill_points,
+    current_health: char.current_health,
+    max_health: char.max_health,
+    current_stamina: char.current_stamina,
+    equipment_attack,
+    equipment_defense,
+    usable_clan_members: usableClanMembers,
+    unbanked_currency: char.unbanked_currency,
+    banked_currency: char.banked_currency,
+  };
+}
+
+// Increment a character's trophy counters (upsert so it works without a row).
+export function bumpTrophies(
+  db: D1Database,
+  characterId: string,
+  delta: { wins?: number; losses?: number; kills?: number; deaths?: number },
+) {
+  const w = delta.wins ?? 0;
+  const l = delta.losses ?? 0;
+  const k = delta.kills ?? 0;
+  const d = delta.deaths ?? 0;
+  return db
+    .prepare(`
+      INSERT INTO trophies (character_id, wins, losses, kills, deaths)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(character_id) DO UPDATE SET
+        wins = wins + excluded.wins,
+        losses = losses + excluded.losses,
+        kills = kills + excluded.kills,
+        deaths = deaths + excluded.deaths
+    `)
+    .bind(characterId, w, l, k, d);
+}

--- a/workers/src/core/bots.ts
+++ b/workers/src/core/bots.ts
@@ -1,0 +1,114 @@
+import type { Bindings } from '../bindings';
+import { resolveBattle } from './storm8-battle-engine';
+import { getCharacterBattleStats, bumpTrophies } from './battle';
+
+// How many bot attacks to run per cron tick (keeps the game "alive" 24/7 while
+// bounding DB growth).
+const ATTACKS_PER_TICK = 15;
+
+// Pick a batch of bots and have each attack a real opponent, resolving the
+// battle exactly like a player attack (initiative, multi-hit, counter, kills,
+// trophies, currency). Called from the scheduled (cron) handler.
+export async function runBotAttacks(env: Bindings): Promise<void> {
+  const db = env.DB;
+
+  // Bots that can act this tick: alive and have stamina.
+  const bots = await db
+    .prepare(`
+      SELECT c.id, c.level
+      FROM characters c JOIN users u ON u.id = c.user_id
+      WHERE u.username LIKE 'bot\\_%' ESCAPE '\\'
+        AND c.current_health > 0 AND c.current_stamina >= 1
+      ORDER BY RANDOM() LIMIT ?
+    `)
+    .bind(ATTACKS_PER_TICK)
+    .all<{ id: string; level: number }>();
+
+  for (const bot of bots.results || []) {
+    try {
+      await botAttackOnce(db, bot.id, bot.level);
+    } catch (e) {
+      console.error('Bot attack failed:', e);
+    }
+  }
+}
+
+async function botAttackOnce(db: D1Database, attackerId: string, attackerLevel: number): Promise<void> {
+  // Pick a random living target at the attacker's level or higher (so bots
+  // "punch up/sideways" and never farm lower-level players — same spirit as the
+  // level-bracket rule).
+  const target = await db
+    .prepare(`
+      SELECT c.id, c.user_id
+      FROM characters c
+      WHERE c.first_game_access_completed = 1 AND c.current_health > 0
+        AND c.id != ? AND c.level >= ?
+      ORDER BY RANDOM() LIMIT 1
+    `)
+    .bind(attackerId, attackerLevel)
+    .first<{ id: string; user_id: string }>();
+  if (!target) return;
+
+  // Respect the target owner's designated defense character.
+  let defenderId = target.id;
+  const owner = await db
+    .prepare('SELECT defense_character_id FROM users WHERE id = ?')
+    .bind(target.user_id)
+    .first<{ defense_character_id: string | null }>();
+  if (owner?.defense_character_id) {
+    const dc = await db
+      .prepare('SELECT id FROM characters WHERE id = ? AND user_id = ?')
+      .bind(owner.defense_character_id, target.user_id)
+      .first<{ id: string }>();
+    if (dc) defenderId = dc.id;
+  }
+  if (defenderId === attackerId) return;
+
+  const attacker = await getCharacterBattleStats(db, attackerId);
+  const defender = await getCharacterBattleStats(db, defenderId);
+  if (!attacker || !defender) return;
+  if (attacker.current_health <= 0 || defender.current_health <= 0 || attacker.current_stamina < 1) return;
+
+  const seed = crypto.randomUUID();
+  const result = resolveBattle(attacker, defender, seed, {}, false, true);
+
+  const battleId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const statements = [
+    db.prepare('UPDATE characters SET current_stamina = current_stamina - 1 WHERE id = ?').bind(attacker.id),
+    db.prepare('UPDATE characters SET current_health = ? WHERE id = ?').bind(result.defender_health_after, defender.id),
+    db.prepare('UPDATE characters SET current_health = ? WHERE id = ?').bind(result.attacker_health_after, attacker.id),
+    db.prepare(`
+      INSERT INTO battles (id, attacker_char_id, defender_char_id, mode, state, seed, battle_type, started_at, ended_at, winner_char_id, currency_stolen, defender_health_after)
+      VALUES (?, ?, ?, 'async', 'completed', ?, 'normal', ?, ?, ?, ?, ?)
+    `).bind(battleId, attacker.id, defender.id, seed, now, now, result.attacker_won ? attacker.id : defender.id, result.currency_stolen, result.defender_health_after),
+  ];
+
+  if (result.currency_stolen > 0) {
+    statements.push(
+      db.prepare('UPDATE characters SET unbanked_currency = unbanked_currency + ? WHERE id = ?').bind(result.currency_stolen, attacker.id),
+      db.prepare('UPDATE characters SET unbanked_currency = unbanked_currency - ? WHERE id = ?').bind(result.currency_stolen, defender.id),
+    );
+  }
+
+  if (result.defender_killed) {
+    statements.push(bumpTrophies(db, attacker.id, { kills: 1, wins: 1 }), bumpTrophies(db, defender.id, { deaths: 1, losses: 1 }));
+  } else if (result.attacker_killed) {
+    statements.push(bumpTrophies(db, defender.id, { kills: 1, wins: 1 }), bumpTrophies(db, attacker.id, { deaths: 1, losses: 1 }));
+  } else {
+    statements.push(
+      bumpTrophies(db, attacker.id, result.attacker_won ? { wins: 1 } : { losses: 1 }),
+      bumpTrophies(db, defender.id, result.attacker_won ? { losses: 1 } : { wins: 1 }),
+    );
+  }
+
+  statements.push(
+    db.prepare('INSERT INTO battle_feed (character_id, battle_id, attacker_id, defender_id, attacker_won, damage_dealt, currency_stolen) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .bind(attacker.id, battleId, attacker.id, defender.id, result.attacker_won, result.damage_dealt, result.currency_stolen),
+    db.prepare('INSERT INTO battle_feed (character_id, battle_id, attacker_id, defender_id, attacker_won, damage_dealt, currency_stolen) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .bind(defender.id, battleId, attacker.id, defender.id, result.attacker_won, result.damage_dealt, result.currency_stolen),
+  );
+
+  await db.batch(statements);
+}

--- a/workers/src/core/cron.ts
+++ b/workers/src/core/cron.ts
@@ -1,6 +1,7 @@
 import type { Bindings } from "../bindings";
 import { checkForLevelUp } from "./leveling";
 import { applyResourceRegeneration } from "./regen";
+import { runBotAttacks } from "./bots";
 
 interface CharacterWithLedger {
     id: string;
@@ -8,6 +9,7 @@ interface CharacterWithLedger {
     level: number;
     created_at: string;
     last_updated: string | null;
+    username: string;
 }
 
 export async function handleScheduled(env: Bindings) {
@@ -18,8 +20,9 @@ export async function handleScheduled(env: Bindings) {
     try {
         // This query finds all characters and the timestamp of their last XP award.
         const charactersToUpdate = await db.prepare(`
-            SELECT c.id, c.xp, c.level, c.created_at, MAX(l.to_ts) as last_updated
+            SELECT c.id, c.xp, c.level, c.created_at, u.username, MAX(l.to_ts) as last_updated
             FROM characters c
+            JOIN users u ON u.id = c.user_id
             LEFT JOIN offline_xp_ledger l ON c.id = l.character_id
             GROUP BY c.id
         `).all<CharacterWithLedger>();
@@ -33,6 +36,9 @@ export async function handleScheduled(env: Bindings) {
         const dailyCap = parseInt(env.DAILY_XP_CAP, 10);
 
         for (const char of charactersToUpdate.results) {
+            // Bots stay at their seeded level (no offline XP), but still regen below.
+            if (char.username && char.username.startsWith('bot_')) continue;
+
             const lastUpdated = char.last_updated ? new Date(char.last_updated) : new Date(char.created_at);
             const hoursPassed = Math.min((now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60), 24);
 
@@ -81,6 +87,10 @@ export async function handleScheduled(env: Bindings) {
         for (const char of charactersToUpdate.results) {
             await applyResourceRegeneration(db, char.id);
         }
+
+        // Keep the world alive: bots attack on their own each tick.
+        console.log('Cron job: running bot attacks');
+        await runBotAttacks(env);
     } catch (e) {
         console.error('Cron job error:', e);
     }


### PR DESCRIPTION
## Bots play 24/7 (game continues offline)
The every-5-minute cron now runs **`runBotAttacks`**: a batch of bots (with stamina, alive) each attack a random **living target at their level or higher** (so they punch up/sideways, never farm lower players — same spirit as the level-bracket rule), respecting the target's **defense character**. Each fight resolves exactly like a player attack — initiative, multi-hit, counterattack, kills, trophies, currency steal, battle feed. So the leaderboard, feeds, and your "you were attacked" history stay alive while you're offline.

- Bots are **excluded from offline XP** so they hold their seeded levels (1–275) with points allocated, but they still **regenerate** so they recover between fights.
- Extracted **`core/battle.ts`** (`getCharacterBattleStats`, `bumpTrophies`) shared by the live attack endpoints and the bot loop.

## AI assistant is now a game expert
The voice assistant's system prompt is a detailed **.shade coach**: classes and base stats, point-placement rules (HP +100, SPD +2, ATK/DEF +1% of base), the speed → first-strike/multi-hit math, mitigation damage, dragons' DEF+SPD attack bonus, regen/hospital, and concrete build strategies. Ask it "I'm a Dragon, where do I put points?" and it gives real advice.

## Verification
- `npm run build` ✅ • `npm run typecheck` ✅
- Post-deploy: confirm a cron tick creates new bot battles, and the assistant answers strategy questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)