### PR TITLE
Gamer profiles: social-profile link + attack link

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
   route("groups", "routes/groups.tsx"),
   route("messages", "routes/messages.tsx"),
   route("profile/me", "routes/profile.me.tsx"),
+  route("u/:id", "routes/u.$id.tsx"),  // Public social profile
   route("settings", "routes/settings.tsx"),
 
   // Game Routes (under /shade prefix)

--- a/app/routes/shade.profile.tsx
+++ b/app/routes/shade.profile.tsx
@@ -220,6 +220,12 @@ export default function GamerProfilePage() {
             >
               Dashboard
             </Link>
+            <Link
+              to="/profile/me"
+              className="text-xs px-3 py-1.5 bg-shade-black-800 border border-social-green-600/50 text-social-green-300 rounded hover:border-social-green-400 hover:text-social-green-200 transition-all"
+            >
+              Social profile
+            </Link>
           </div>
         </div>
       </div>

--- a/app/routes/shade.u.$username.tsx
+++ b/app/routes/shade.u.$username.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { apiClient } from "../lib/api";
+import { useAuth } from "../lib/AuthContext";
+import { useBattleResult } from "../lib/BattleResultContext";
 import { ProfileComments } from "../components/ProfileComments";
 
 type PublicChar = {
@@ -14,6 +16,7 @@ type PublicChar = {
 };
 
 type PublicProfile = {
+  id: string;
   username: string;
   shade_avatar_url: string | null;
   created_at: string | null;
@@ -23,10 +26,13 @@ type PublicProfile = {
 // Public profile: trophies only. Combat stats are private to the owner.
 export default function PublicProfilePage() {
   const { username } = useParams();
+  const { user, isAuthenticated } = useAuth();
+  const { showBattle } = useBattleResult();
   const [profile, setProfile] = useState<PublicProfile | null>(null);
   const [characters, setCharacters] = useState<PublicChar[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [attacking, setAttacking] = useState(false);
 
   useEffect(() => {
     if (!username) return;
@@ -43,6 +49,22 @@ export default function PublicProfilePage() {
   const avatar = profile.shade_avatar_url;
   const totalWins = characters.reduce((s, c) => s + (c.wins ?? 0), 0);
   const totalKills = characters.reduce((s, c) => s + (c.kills ?? 0), 0);
+  const isOwnProfile = isAuthenticated && user?.username?.toLowerCase() === profile.username?.toLowerCase();
+
+  const attack = async () => {
+    const target = characters[0]?.gamertag;
+    if (!target) return;
+    setAttacking(true);
+    setError(null);
+    try {
+      const res = await apiClient.post<{ data: any }>("/storm8/attack", { defender_gamertag: target });
+      showBattle(res.data);
+    } catch (e: any) {
+      setError(e?.message || "Attack failed");
+    } finally {
+      setAttacking(false);
+    }
+  };
 
   return (
     <div className="max-w-4xl mx-auto p-4 space-y-6">
@@ -63,7 +85,25 @@ export default function PublicProfilePage() {
           {profile.defender_gamertag && (
             <p className="text-sm text-sky-300 mt-2">🛡️ Defender: <span className="font-bold">{profile.defender_gamertag}</span></p>
           )}
-          <Link to="/shade/leaderboard" className="text-xs text-shade-red-400 hover:text-shade-red-200 mt-3 inline-block">← Leaderboard</Link>
+          <div className="flex flex-wrap gap-2 justify-center sm:justify-start mt-3">
+            {isAuthenticated && !isOwnProfile && characters.length > 0 && (
+              <button
+                onClick={attack}
+                disabled={attacking}
+                className="px-4 py-2 rounded-lg font-bold text-white bg-gradient-to-r from-shade-red-700 to-shade-red-500 hover:from-shade-red-600 hover:to-shade-red-400 transition-all shadow-lg shadow-shade-red-900/40 disabled:opacity-60"
+              >
+                {attacking ? "Attacking…" : "⚔ Attack"}
+              </button>
+            )}
+            <Link
+              to={`/u/${encodeURIComponent(profile.id)}`}
+              className="px-4 py-2 rounded-lg bg-shade-black-800 border border-social-green-600/50 text-social-green-300 hover:border-social-green-400 hover:text-social-green-200 transition-all text-sm"
+            >
+              Social profile
+            </Link>
+            <Link to="/shade/leaderboard" className="px-4 py-2 rounded-lg bg-shade-black-800 border border-shade-red-800/50 text-shade-red-300 hover:text-shade-red-100 transition-all text-sm">← Leaderboard</Link>
+          </div>
+          {error && <p className="text-shade-red-500 text-sm mt-2">{error}</p>}
         </div>
       </div>
 

--- a/app/routes/u.$id.tsx
+++ b/app/routes/u.$id.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { apiClient } from "../lib/api";
+
+// Public social profile (read-only). Combat stats stay private — for those,
+// link out to the game/gamer profile (which shows trophies only).
+type SocialProfile = {
+  username: string;
+  avatar_url?: string | null;
+  bio?: string | null;
+  cover_photo_url?: string | null;
+  created_at?: string | null;
+};
+
+export default function PublicSocialProfilePage() {
+  const { id } = useParams();
+  const [profile, setProfile] = useState<SocialProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    apiClient.get<{ data: SocialProfile }>(`/users/${encodeURIComponent(id)}/profile`)
+      .then((r) => setProfile(r.data))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <div className="p-6 text-center text-social-green-600">Loading profile…</div>;
+  if (error || !profile) return <div className="p-6 text-center text-red-600">{error || "Profile not found"}</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Cover */}
+      <div className="h-40 sm:h-52 rounded-b-2xl overflow-hidden bg-gradient-to-r from-social-green-600 to-social-green-400">
+        {profile.cover_photo_url && (
+          <img src={profile.cover_photo_url} alt="" className="w-full h-full object-cover" />
+        )}
+      </div>
+
+      <div className="px-4 -mt-12">
+        <div className="flex items-end gap-4">
+          {profile.avatar_url ? (
+            <img src={profile.avatar_url} alt={profile.username} className="w-24 h-24 rounded-full ring-4 ring-white object-cover bg-white" />
+          ) : (
+            <div className="w-24 h-24 rounded-full ring-4 ring-white bg-gradient-to-br from-social-green-400 to-social-green-600 flex items-center justify-center text-white text-3xl font-bold">
+              {profile.username?.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <div className="pb-2">
+            <h1 className="text-2xl font-bold text-social-forest-700">{profile.username}</h1>
+            {profile.created_at && (
+              <p className="text-xs text-social-forest-400">Joined {new Date(profile.created_at).toLocaleDateString()}</p>
+            )}
+          </div>
+        </div>
+
+        {profile.bio && (
+          <p className="mt-4 text-social-forest-600 whitespace-pre-wrap">{profile.bio}</p>
+        )}
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            to={`/shade/u/${encodeURIComponent(profile.username)}`}
+            className="px-5 py-2.5 rounded-xl font-semibold text-white bg-gradient-to-r from-shade-red-700 to-fuchsia-600 hover:from-shade-red-600 hover:to-fuchsia-500 transition-all shadow-lg shadow-fuchsia-900/30"
+          >
+            ⚔ Game profile
+          </Link>
+          <Link
+            to="/feed"
+            className="px-5 py-2.5 rounded-xl font-semibold bg-social-cream-200 text-social-forest-700 hover:bg-social-cream-300 transition-all"
+          >
+            ← Back to me
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/workers/src/api/game.ts
+++ b/workers/src/api/game.ts
@@ -441,6 +441,7 @@ game.get('/profile/:name', async (c) => {
     return c.json({
         data: {
             profile: {
+                id: u.id,
                 username: u.username,
                 shade_avatar_url: u.shade_avatar_url,
                 created_at: u.created_at,


### PR DESCRIPTION
Every gamer profile now links to the social side and can launch an attack.

- **New public social profile** page `/u/:id` (read-only: cover, avatar, bio) with a link back to the game profile. Combat stats remain private.
- `/game/profile/:name` returns the user `id` for cross-linking.
- **Public gamer profile** (`/shade/u/:name`): a **Social profile** link and an **⚔ Attack** button — attacks that player through the global battle overlay (respects their defense character; hidden on your own profile and when logged out).
- **Own gamer profile** (`/shade/profile`): a **Social profile** link to `/profile/me`.

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)