### PR TITLE
Bot names consistent (gamertag) + is_bot flag

### DIFF
--- a/migrations/0017_bot_flag_and_names.sql
+++ b/migrations/0017_bot_flag_and_names.sql
@@ -1,0 +1,17 @@
+-- Mark bot accounts with a stable flag (so renaming their usernames doesn't
+-- break the bot loop), then give each bot a consistent public name: set its
+-- account username to its character's gamertag (e.g. "Wisp_275" instead of the
+-- internal "bot_275"). Gamertags are already unique, so usernames stay unique.
+
+ALTER TABLE users ADD COLUMN is_bot INTEGER DEFAULT 0;
+
+UPDATE users SET is_bot = 1
+  WHERE username LIKE 'bot\_%' ESCAPE '\' OR email LIKE '%@bots.shade';
+
+UPDATE users SET username = (
+    SELECT c.gamertag FROM characters c
+    WHERE c.user_id = users.id AND c.gamertag IS NOT NULL
+    ORDER BY c.slot_number LIMIT 1
+  )
+  WHERE is_bot = 1
+    AND EXISTS (SELECT 1 FROM characters c WHERE c.user_id = users.id AND c.gamertag IS NOT NULL);

--- a/workers/src/core/bots.ts
+++ b/workers/src/core/bots.ts
@@ -17,7 +17,7 @@ export async function runBotAttacks(env: Bindings): Promise<void> {
     .prepare(`
       SELECT c.id, c.level
       FROM characters c JOIN users u ON u.id = c.user_id
-      WHERE u.username LIKE 'bot\\_%' ESCAPE '\\'
+      WHERE u.is_bot = 1
         AND c.current_health > 0 AND c.current_stamina >= 1
       ORDER BY RANDOM() LIMIT ?
     `)

--- a/workers/src/core/cron.ts
+++ b/workers/src/core/cron.ts
@@ -9,7 +9,7 @@ interface CharacterWithLedger {
     level: number;
     created_at: string;
     last_updated: string | null;
-    username: string;
+    is_bot: number;
 }
 
 export async function handleScheduled(env: Bindings) {
@@ -20,7 +20,7 @@ export async function handleScheduled(env: Bindings) {
     try {
         // This query finds all characters and the timestamp of their last XP award.
         const charactersToUpdate = await db.prepare(`
-            SELECT c.id, c.xp, c.level, c.created_at, u.username, MAX(l.to_ts) as last_updated
+            SELECT c.id, c.xp, c.level, c.created_at, u.is_bot, MAX(l.to_ts) as last_updated
             FROM characters c
             JOIN users u ON u.id = c.user_id
             LEFT JOIN offline_xp_ledger l ON c.id = l.character_id
@@ -37,7 +37,7 @@ export async function handleScheduled(env: Bindings) {
 
         for (const char of charactersToUpdate.results) {
             // Bots stay at their seeded level (no offline XP), but still regen below.
-            if (char.username && char.username.startsWith('bot_')) continue;
+            if (char.is_bot) continue;
 
             const lastUpdated = char.last_updated ? new Date(char.last_updated) : new Date(char.created_at);
             const hoursPassed = Math.min((now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60), 24);


### PR DESCRIPTION
Bots showed their internal account username (`bot_275`) on profiles even though their gamertag was `Wisp_275`.

- **Migration 0017:** add `users.is_bot`, flag the bots, and set each bot's **username = its gamertag** (already unique → usernames stay unique, no more "bot").
- Switched the cron's XP-exclusion and the bot-attack loop to use the **`is_bot` flag** instead of a `username LIKE 'bot_%'` prefix (which no longer matches after the rename).

Applied to remote; verified usernames now equal gamertags (Wisp_275, Umbra_274, …).

npm run build ✅ • typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)