### PR TITLE
feat(auth): GitHub & Discord social login

### DIFF
--- a/app/components/OAuthButtons.tsx
+++ b/app/components/OAuthButtons.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import { apiClient } from '../lib/api';
+
+type Provider = { id: string; label: string };
+
+// Per-provider brand styling + icon. Anything not listed still renders with a
+// neutral fallback, so adding a backend provider needs no frontend change.
+const BRAND: Record<string, { className: string; icon: ReactElement }> = {
+  github: {
+    className: 'bg-[#24292f] hover:bg-[#1b1f23] text-white',
+    icon: (
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.1 3.29 9.41 7.86 10.94.58.11.79-.25.79-.56 0-.27-.01-1-.02-1.96-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.41.36.78 1.06.78 2.14 0 1.55-.01 2.8-.01 3.18 0 .31.21.68.8.56A11.53 11.53 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5Z" />
+      </svg>
+    ),
+  },
+  discord: {
+    className: 'bg-[#5865F2] hover:bg-[#4752c4] text-white',
+    icon: (
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M20.32 4.37A19.8 19.8 0 0 0 15.45 2.9a.07.07 0 0 0-.08.04c-.21.38-.45.87-.61 1.25a18.3 18.3 0 0 0-5.5 0 12.6 12.6 0 0 0-.62-1.25.07.07 0 0 0-.08-.04A19.74 19.74 0 0 0 3.7 4.37a.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06a.08.08 0 0 0 .03.05 19.9 19.9 0 0 0 5.99 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.29 1.23-1.99a.08.08 0 0 0-.04-.11c-.65-.25-1.27-.55-1.87-.89a.08.08 0 0 1-.01-.13c.13-.1.25-.2.37-.3a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.24.2.37.3a.08.08 0 0 1-.01.13c-.6.35-1.22.64-1.87.89a.08.08 0 0 0-.04.11c.36.7.78 1.36 1.23 1.99a.08.08 0 0 0 .08.03 19.84 19.84 0 0 0 6-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.56-13.66a.06.06 0 0 0-.03-.03ZM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42 0-1.33.96-2.42 2.16-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42Zm7.97 0c-1.18 0-2.16-1.08-2.16-2.42 0-1.33.96-2.42 2.16-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.34-.95 2.42-2.16 2.42Z" />
+      </svg>
+    ),
+  },
+};
+
+const FALLBACK = {
+  className: 'bg-social-forest-600 hover:bg-social-forest-700 text-white',
+  icon: (
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5Z" />
+    </svg>
+  ),
+};
+
+export function OAuthButtons() {
+  const [providers, setProviders] = useState<Provider[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    apiClient
+      .get<{ data: Provider[] }>('/auth/oauth/providers')
+      .then((res) => {
+        if (active) setProviders(res.data || []);
+      })
+      .catch(() => {
+        // Endpoint missing or no providers configured — render nothing.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (providers.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {providers.map((p) => {
+        const brand = BRAND[p.id] ?? FALLBACK;
+        return (
+          <a
+            key={p.id}
+            href={`/api/auth/oauth/${p.id}/start`}
+            className={`flex items-center justify-center gap-2 w-full py-3 rounded-lg font-semibold transition-colors ${brand.className}`}
+          >
+            {brand.icon}
+            <span>Continue with {p.label}</span>
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,16 +1,31 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { apiClient } from '../lib/api';
 import { useAuth } from '../lib/AuthContext';
 import { GoogleLoginButton } from '../components/GoogleLoginButton';
+import { OAuthButtons } from '../components/OAuthButtons';
 import { MagicLinkAuthCard } from '../components/MagicLinkAuthCard';
+
+// Friendly text for ?error=... codes returned by the OAuth redirect flow.
+const OAUTH_ERRORS: Record<string, string> = {
+    oauth_denied: 'Sign-in was cancelled.',
+    oauth_state: 'Sign-in session expired. Please try again.',
+    oauth_failed: 'Could not sign you in with that provider. Please try again.',
+    provider_unavailable: 'That sign-in provider is not available right now.',
+};
 
 export default function LoginPage() {
     const navigate = useNavigate();
     const { login } = useAuth();
+    const [searchParams] = useSearchParams();
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const code = searchParams.get('error');
+        if (code) setError(OAUTH_ERRORS[code] || 'Sign-in failed. Please try again.');
+    }, [searchParams]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -95,6 +110,8 @@ export default function LoginPage() {
                             onError={(err) => setError(err)}
                         />
                     </div>
+
+                    <OAuthButtons />
 
                     <div className="border-t border-gray-300 pt-4 mt-4">
                         <Link

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { apiClient } from '../lib/api';
 import { GoogleLoginButton } from '../components/GoogleLoginButton';
+import { OAuthButtons } from '../components/OAuthButtons';
 import { MagicLinkAuthCard } from '../components/MagicLinkAuthCard';
 
 export default function RegisterPage() {
@@ -101,6 +102,8 @@ export default function RegisterPage() {
                             onError={(err) => setError(err)}
                         />
                     </div>
+
+                    <OAuthButtons />
 
                     <div className="text-center pt-4 border-t border-gray-300 mt-4">
                         <Link to="/login" className="text-social-green-600 hover:underline font-medium">

--- a/docs/SOCIAL_LOGIN.md
+++ b/docs/SOCIAL_LOGIN.md
@@ -1,0 +1,75 @@
+# Social login (OAuth)
+
+The site supports several ways to sign in:
+
+| Method | Type | Code |
+|---|---|---|
+| Email + password | local | `workers/src/api/auth.ts` |
+| Magic link (email) | passwordless | `workers/src/api/auth.ts` |
+| Google | client-side id-token | `workers/src/api/auth.ts` + `app/components/GoogleLoginButton.tsx` |
+| **GitHub, Discord** | **server-side OAuth2 (authorization code)** | `workers/src/api/oauth.ts` + `workers/src/core/oauth-providers.ts` |
+
+The GitHub/Discord flow is **config-driven**: a provider's button only appears once
+its client id **and** secret are set as Worker secrets. With nothing configured,
+the buttons simply don't render — no broken UI.
+
+## How the redirect flow works
+
+1. User clicks **Continue with GitHub/Discord** → browser hits
+   `GET /api/auth/oauth/:provider/start`.
+2. The Worker sets a short-lived CSRF `oauth_state_<provider>` cookie and 302s to
+   the provider's authorize URL.
+3. Provider sends the user back to
+   `GET /api/auth/oauth/:provider/callback?code=…&state=…`.
+4. The Worker verifies `state`, exchanges `code` for the profile, then
+   **find-or-link-or-create**s the user:
+   - links to an existing provider account, else
+   - links to an existing user with the **same verified email**, else
+   - creates a new user + starter character + trophies.
+5. Sets the `session_token` cookie and redirects into the app
+   (`/feed`, or `/profile/me?welcome=1` for brand-new accounts).
+
+`GET /api/auth/oauth/providers` returns the list of currently-enabled providers;
+the frontend (`app/components/OAuthButtons.tsx`) uses it to decide which buttons
+to show.
+
+## Enabling a provider
+
+### 1. Register an OAuth app
+
+**GitHub** — Settings → Developer settings → OAuth Apps → New OAuth App
+- Homepage URL: `https://hwmnbn.me`
+- Authorization callback URL: `https://hwmnbn.me/api/auth/oauth/github/callback`
+
+**Discord** — https://discord.com/developers/applications → New Application → OAuth2
+- Redirect: `https://hwmnbn.me/api/auth/oauth/discord/callback`
+- Scopes used: `identify email`
+
+> The callback URL must match **exactly**, including scheme and path.
+
+### 2. Set the Worker secrets
+
+```bash
+npx wrangler secret put GITHUB_CLIENT_ID
+npx wrangler secret put GITHUB_CLIENT_SECRET
+npx wrangler secret put DISCORD_CLIENT_ID
+npx wrangler secret put DISCORD_CLIENT_SECRET
+```
+
+(Client ids aren't sensitive, but storing them as secrets keeps all provider
+config in one place. They could also be `[vars]` in `wrangler.toml`.)
+
+After the secrets are live, the corresponding button appears automatically.
+
+## Adding another provider
+
+Most OAuth2 providers (Microsoft, GitLab, Twitch, …) drop in with ~15 lines:
+
+1. Add its `*_CLIENT_ID` / `*_CLIENT_SECRET` to `workers/src/bindings.ts`.
+2. Add an `xyzExchange()` and a `case 'xyz'` in
+   `workers/src/core/oauth-providers.ts`, and list it in `KNOWN_PROVIDERS`.
+3. (Optional) add brand styling/icon in `app/components/OAuthButtons.tsx` —
+   otherwise it renders with a neutral fallback.
+
+No new routes or migrations are needed; `oauth_accounts` already stores any
+`(provider, provider_account_id)` pair.

--- a/workers/src/api/auth.ts
+++ b/workers/src/api/auth.ts
@@ -13,7 +13,7 @@ import { rollInitialCharacter, sanitizeGamertag } from '../core/classes';
 const auth = new Hono<{ Bindings: Bindings }>();
 
 // Build the INSERT for a brand-new, immediately-playable character (gamertag + class + base stats).
-async function buildInitialCharacter(db: D1Database, characterId: string, userId: string, seedUsername: string, founder: boolean) {
+export async function buildInitialCharacter(db: D1Database, characterId: string, userId: string, seedUsername: string, founder: boolean) {
   const gamertag = await generateUniqueGamertag(db, sanitizeGamertag(seedUsername));
   const c = rollInitialCharacter({ seed: userId, autoMax: founder });
   return db.prepare(
@@ -251,7 +251,7 @@ async function ensureUserFromGoogle(db: D1Database, profile: GoogleTokenPayload)
   };
 }
 
-async function generateUniqueUsername(db: D1Database, base: string): Promise<string> {
+export async function generateUniqueUsername(db: D1Database, base: string): Promise<string> {
   let candidate = base || 'player';
   let suffix = 0;
   const MAX_ATTEMPTS = 10000;
@@ -266,10 +266,10 @@ async function generateUniqueUsername(db: D1Database, base: string): Promise<str
 }
 
 // Special account usernames that get elevated privileges
-const SPECIAL_USERNAMES = ['trubone'];
+export const SPECIAL_USERNAMES = ['trubone'];
 
 // Helper to check and grant special account status
-async function checkAndGrantSpecialAccount(db: D1Database, userId: string, username: string): Promise<void> {
+export async function checkAndGrantSpecialAccount(db: D1Database, userId: string, username: string): Promise<void> {
   // Check if this is a special username
   if (!SPECIAL_USERNAMES.includes(username.toLowerCase())) {
     return;

--- a/workers/src/api/index.ts
+++ b/workers/src/api/index.ts
@@ -32,6 +32,9 @@ function lazyRoute(
 // Core auth routes - always needed, load eagerly
 import authRoutes from './auth';
 import userRoutes from './users';
+// Social OAuth (GitHub/Discord redirect flow) - lazy loaded. Mounted before
+// `/auth` so /auth/oauth/* resolves to this router rather than the auth router.
+api.route('/auth/oauth', lazyRoute('/api/auth/oauth', () => import('./oauth')));
 api.route('/auth', authRoutes);
 api.route('/users', userRoutes);
 

--- a/workers/src/api/oauth.ts
+++ b/workers/src/api/oauth.ts
@@ -1,0 +1,206 @@
+import { Hono } from 'hono';
+import { setCookie, getCookie, deleteCookie } from 'hono/cookie';
+import type { Bindings } from '../bindings';
+import { createSession } from '../lib/session';
+import {
+  buildInitialCharacter,
+  generateUniqueUsername,
+  checkAndGrantSpecialAccount,
+  SPECIAL_USERNAMES,
+} from './auth';
+import { getProvider, listEnabledProviders, type NormalizedProfile } from '../core/oauth-providers';
+
+// Server-side OAuth2 (authorization-code) login for social providers
+// (GitHub, Discord, …). Distinct from the Google flow in auth.ts, which is a
+// client-side Google Identity Services id-token exchange.
+//
+// Mounted at /api/auth/oauth, so routes here are relative: /providers,
+// /:provider/start, /:provider/callback.
+const oauth = new Hono<{ Bindings: Bindings }>();
+
+function appUrl(c: any): string {
+  return c.env.APP_URL || new URL(c.req.url).origin;
+}
+
+function callbackUrl(c: any, providerId: string): string {
+  return `${appUrl(c)}/api/auth/oauth/${providerId}/callback`;
+}
+
+function isHttps(c: any): boolean {
+  return c.req.url.startsWith('https://') || appUrl(c).startsWith('https://');
+}
+
+const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+const STATE_MAX_AGE = 60 * 10; // 10 minutes
+
+// Which social providers are usable right now (configured with secrets). The
+// frontend uses this to decide which buttons to render.
+oauth.get('/providers', (c) => {
+  return c.json({ data: listEnabledProviders(c.env) });
+});
+
+// Kick off the flow: set a CSRF state cookie and redirect to the provider.
+oauth.get('/:provider/start', async (c) => {
+  const providerId = c.req.param('provider');
+  const provider = getProvider(providerId, c.env);
+  if (!provider) {
+    return c.redirect(`${appUrl(c)}/login?error=provider_unavailable`);
+  }
+
+  const state = crypto.randomUUID();
+  setCookie(c, `oauth_state_${providerId}`, state, {
+    httpOnly: true,
+    secure: isHttps(c),
+    sameSite: 'Lax',
+    path: '/',
+    maxAge: STATE_MAX_AGE,
+  });
+
+  const params = new URLSearchParams({
+    client_id: provider.clientId,
+    redirect_uri: callbackUrl(c, providerId),
+    response_type: 'code',
+    scope: provider.scope,
+    state,
+    ...(provider.extraAuthParams || {}),
+  });
+
+  return c.redirect(`${provider.authorizeUrl}?${params.toString()}`);
+});
+
+// Provider redirects back here with ?code & ?state. Verify state, exchange the
+// code, provision/link the user, set the session cookie, bounce into the app.
+oauth.get('/:provider/callback', async (c) => {
+  const providerId = c.req.param('provider');
+  const base = appUrl(c);
+  const provider = getProvider(providerId, c.env);
+  if (!provider) return c.redirect(`${base}/login?error=provider_unavailable`);
+
+  const url = new URL(c.req.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const denied = url.searchParams.get('error');
+
+  const cookieName = `oauth_state_${providerId}`;
+  const cookieState = getCookie(c, cookieName);
+  deleteCookie(c, cookieName, { path: '/' });
+
+  if (denied) return c.redirect(`${base}/login?error=oauth_denied`);
+  if (!code || !state || !cookieState || state !== cookieState) {
+    return c.redirect(`${base}/login?error=oauth_state`);
+  }
+
+  try {
+    const profile = await provider.exchange(code, callbackUrl(c, providerId));
+    const result = await ensureUserFromOAuth(c.env.DB, providerId, profile);
+
+    await checkAndGrantSpecialAccount(c.env.DB, result.id, result.username);
+
+    const sessionToken = await createSession(c.env.DB, result.id);
+    setCookie(c, 'session_token', sessionToken, {
+      httpOnly: true,
+      secure: isHttps(c),
+      sameSite: 'Lax',
+      path: '/',
+      maxAge: SESSION_MAX_AGE,
+    });
+
+    const dest = result.needs_username_confirmation ? '/profile/me?welcome=1' : '/feed';
+    return c.redirect(`${base}${dest}`);
+  } catch (err: any) {
+    console.error(`OAuth callback failed (${providerId}):`, err?.message || err);
+    return c.redirect(`${base}/login?error=oauth_failed`);
+  }
+});
+
+type EnsureResult = { id: string; username: string; needs_username_confirmation: boolean };
+
+// Find-or-link-or-create a user for a normalized social profile.
+async function ensureUserFromOAuth(
+  db: D1Database,
+  provider: string,
+  profile: NormalizedProfile,
+): Promise<EnsureResult> {
+  const rawProfileJson = JSON.stringify(profile.raw);
+
+  // 1) Already linked: this exact provider account is known.
+  const linked = await db
+    .prepare(
+      `SELECT u.id, u.username, u.avatar_url
+       FROM oauth_accounts oa JOIN users u ON oa.user_id = u.id
+       WHERE oa.provider = ? AND oa.provider_account_id = ?`,
+    )
+    .bind(provider, profile.providerAccountId)
+    .first<{ id: string; username: string; avatar_url: string | null }>();
+
+  if (linked) {
+    await db
+      .prepare(
+        `UPDATE oauth_accounts SET raw_profile_json = ?, scope = ?
+         WHERE provider = ? AND provider_account_id = ?`,
+      )
+      .bind(rawProfileJson, profile.scope, provider, profile.providerAccountId)
+      .run();
+    if (profile.avatarUrl && !linked.avatar_url) {
+      await db.prepare('UPDATE users SET avatar_url = ? WHERE id = ?').bind(profile.avatarUrl, linked.id).run();
+    }
+    return { id: linked.id, username: linked.username, needs_username_confirmation: false };
+  }
+
+  // 2) Link to an existing account by verified email (so signing in with a
+  //    provider that shares your email attaches to your current account rather
+  //    than making a duplicate). Only when the provider verified the address.
+  if (profile.email && profile.emailVerified) {
+    const existing = await db
+      .prepare('SELECT id, username, avatar_url FROM users WHERE email = ?')
+      .bind(profile.email)
+      .first<{ id: string; username: string; avatar_url: string | null }>();
+    if (existing) {
+      await db
+        .prepare(
+          `INSERT INTO oauth_accounts (id, user_id, provider, provider_account_id, scope, raw_profile_json)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(crypto.randomUUID(), existing.id, provider, profile.providerAccountId, profile.scope, rawProfileJson)
+        .run();
+      if (profile.avatarUrl && !existing.avatar_url) {
+        await db.prepare('UPDATE users SET avatar_url = ? WHERE id = ?').bind(profile.avatarUrl, existing.id).run();
+      }
+      return { id: existing.id, username: existing.username, needs_username_confirmation: false };
+    }
+  }
+
+  // 3) Brand-new user: create account + initial character + trophies + link.
+  const userId = crypto.randomUUID();
+  const characterId = crypto.randomUUID();
+  const email = profile.email ?? `${provider}_${profile.providerAccountId}@${provider}.local`;
+  const baseUsername =
+    (profile.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 12) || `${provider}user`;
+  const username = await generateUniqueUsername(db, baseUsername);
+
+  const characterStmt = await buildInitialCharacter(
+    db,
+    characterId,
+    userId,
+    username,
+    SPECIAL_USERNAMES.includes(username.toLowerCase()),
+  );
+
+  await db.batch([
+    db
+      .prepare('INSERT INTO users (id, email, username, email_verified, avatar_url) VALUES (?, ?, ?, ?, ?)')
+      .bind(userId, email, username, profile.emailVerified ? 1 : 0, profile.avatarUrl),
+    db
+      .prepare(
+        `INSERT INTO oauth_accounts (id, user_id, provider, provider_account_id, scope, raw_profile_json)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(crypto.randomUUID(), userId, provider, profile.providerAccountId, profile.scope, rawProfileJson),
+    characterStmt,
+    db.prepare('INSERT INTO trophies (character_id) VALUES (?)').bind(characterId),
+  ]);
+
+  return { id: userId, username, needs_username_confirmation: true };
+}
+
+export default oauth;

--- a/workers/src/bindings.ts
+++ b/workers/src/bindings.ts
@@ -28,6 +28,13 @@ export type Bindings = {
   // Secrets
   GOOGLE_CLIENT_ID?: string;
 
+  // Social OAuth (authorization-code flow) — server-side client id + secret per
+  // provider. A provider's button only appears once both its id and secret are set.
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  DISCORD_CLIENT_ID?: string;
+  DISCORD_CLIENT_SECRET?: string;
+
   // Square Payment Integration
   SQUARE_ACCESS_TOKEN?: string;
   SQUARE_APPLICATION_ID?: string;

--- a/workers/src/core/oauth-providers.ts
+++ b/workers/src/core/oauth-providers.ts
@@ -1,0 +1,175 @@
+import type { Bindings } from '../bindings';
+
+// A normalized identity returned by every provider's token exchange, so the
+// rest of the auth code never needs to know provider-specific shapes.
+export interface NormalizedProfile {
+  providerAccountId: string;
+  email: string | null;
+  emailVerified: boolean;
+  name: string | null;
+  avatarUrl: string | null;
+  scope: string;
+  raw: unknown;
+}
+
+export interface ResolvedProvider {
+  id: string;
+  label: string;
+  clientId: string;
+  authorizeUrl: string;
+  scope: string;
+  // Extra params appended to the authorize redirect (e.g. Discord `prompt`).
+  extraAuthParams?: Record<string, string>;
+  // Exchange the authorization `code` for a normalized user profile.
+  exchange: (code: string, redirectUri: string) => Promise<NormalizedProfile>;
+}
+
+// The ordered list of providers we know how to talk to. To add another social
+// login, append its id here and add a case in `getProvider`.
+export const KNOWN_PROVIDERS = ['discord', 'github'] as const;
+export type ProviderId = (typeof KNOWN_PROVIDERS)[number];
+
+// ---------------------------------------------------------------------------
+// GitHub — https://docs.github.com/en/apps/oauth-apps
+// ---------------------------------------------------------------------------
+async function githubExchange(env: Bindings, code: string, redirectUri: string): Promise<NormalizedProfile> {
+  const scope = 'read:user user:email';
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: new URLSearchParams({
+      client_id: env.GITHUB_CLIENT_ID || '',
+      client_secret: env.GITHUB_CLIENT_SECRET || '',
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+  const tokenJson = (await tokenRes.json()) as { access_token?: string; error?: string };
+  const accessToken = tokenJson.access_token;
+  if (!accessToken) throw new Error(`GitHub token exchange failed: ${tokenJson.error || 'no access_token'}`);
+
+  const ghHeaders = {
+    Authorization: `Bearer ${accessToken}`,
+    'User-Agent': 'shade-me',
+    Accept: 'application/vnd.github+json',
+  };
+
+  const userRes = await fetch('https://api.github.com/user', { headers: ghHeaders });
+  if (!userRes.ok) throw new Error('GitHub profile fetch failed');
+  const u = (await userRes.json()) as {
+    id: number;
+    login: string;
+    name?: string | null;
+    email?: string | null;
+    avatar_url?: string | null;
+  };
+
+  // GitHub may hide the email on /user; pull the verified primary explicitly.
+  let email = u.email ?? null;
+  let emailVerified = !!u.email;
+  if (!email) {
+    const emailsRes = await fetch('https://api.github.com/user/emails', { headers: ghHeaders });
+    if (emailsRes.ok) {
+      const emails = (await emailsRes.json()) as Array<{ email: string; primary: boolean; verified: boolean }>;
+      const chosen = emails.find((e) => e.primary && e.verified) || emails.find((e) => e.verified);
+      if (chosen) {
+        email = chosen.email;
+        emailVerified = true;
+      }
+    }
+  }
+
+  return {
+    providerAccountId: String(u.id),
+    email,
+    emailVerified,
+    name: u.name || u.login,
+    avatarUrl: u.avatar_url ?? null,
+    scope,
+    raw: u,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discord — https://discord.com/developers/docs/topics/oauth2
+// ---------------------------------------------------------------------------
+async function discordExchange(env: Bindings, code: string, redirectUri: string): Promise<NormalizedProfile> {
+  const scope = 'identify email';
+  const body = new URLSearchParams({
+    client_id: env.DISCORD_CLIENT_ID || '',
+    client_secret: env.DISCORD_CLIENT_SECRET || '',
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+  });
+  const tokenRes = await fetch('https://discord.com/api/oauth2/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  const tokenJson = (await tokenRes.json()) as { access_token?: string; error?: string };
+  const accessToken = tokenJson.access_token;
+  if (!accessToken) throw new Error(`Discord token exchange failed: ${tokenJson.error || 'no access_token'}`);
+
+  const userRes = await fetch('https://discord.com/api/users/@me', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!userRes.ok) throw new Error('Discord profile fetch failed');
+  const u = (await userRes.json()) as {
+    id: string;
+    username: string;
+    global_name?: string | null;
+    email?: string | null;
+    verified?: boolean;
+    avatar?: string | null;
+  };
+
+  const avatarUrl = u.avatar ? `https://cdn.discordapp.com/avatars/${u.id}/${u.avatar}.png` : null;
+
+  return {
+    providerAccountId: String(u.id),
+    email: u.email ?? null,
+    emailVerified: !!u.verified,
+    name: u.global_name || u.username,
+    avatarUrl,
+    scope,
+    raw: u,
+  };
+}
+
+// Resolve a provider by id, returning null when it is unknown or not configured
+// (missing client id/secret). Callers treat null as "provider unavailable".
+export function getProvider(id: string, env: Bindings): ResolvedProvider | null {
+  switch (id) {
+    case 'github':
+      if (!env.GITHUB_CLIENT_ID || !env.GITHUB_CLIENT_SECRET) return null;
+      return {
+        id: 'github',
+        label: 'GitHub',
+        clientId: env.GITHUB_CLIENT_ID,
+        authorizeUrl: 'https://github.com/login/oauth/authorize',
+        scope: 'read:user user:email',
+        exchange: (code, redirectUri) => githubExchange(env, code, redirectUri),
+      };
+    case 'discord':
+      if (!env.DISCORD_CLIENT_ID || !env.DISCORD_CLIENT_SECRET) return null;
+      return {
+        id: 'discord',
+        label: 'Discord',
+        clientId: env.DISCORD_CLIENT_ID,
+        authorizeUrl: 'https://discord.com/oauth2/authorize',
+        scope: 'identify email',
+        extraAuthParams: { prompt: 'consent' },
+        exchange: (code, redirectUri) => discordExchange(env, code, redirectUri),
+      };
+    default:
+      return null;
+  }
+}
+
+// The providers that are actually usable right now (configured with secrets).
+export function listEnabledProviders(env: Bindings): Array<{ id: string; label: string }> {
+  return KNOWN_PROVIDERS.map((id) => getProvider(id, env))
+    .filter((p): p is ResolvedProvider => p !== null)
+    .map((p) => ({ id: p.id, label: p.label }));
+}


### PR DESCRIPTION
Adds social login via **GitHub** and **Discord** alongside the existing Google / magic-link / email+password options. Built as a generic, config-driven OAuth2 (authorization-code) system so more providers are a ~15-line addition.

## What's new
- **`workers/src/core/oauth-providers.ts`** — provider registry. Each provider exposes a token-exchange that returns a *normalized* profile. A provider is only "enabled" when its client id **and** secret are configured.
- **`workers/src/api/oauth.ts`** — the redirect flow:
  - `GET /api/auth/oauth/providers` → which providers are live
  - `GET /api/auth/oauth/:provider/start` → sets a CSRF `state` cookie, 302s to the provider
  - `GET /api/auth/oauth/:provider/callback` → verifies state, exchanges the code, **find-or-link-or-create** (links to an existing user by *verified* email instead of duplicating), sets the session cookie, redirects into the app
- Mounted lazily at `/api/auth/oauth` (prefix-stripped) **before** `/auth`.
- Reuses the existing **`oauth_accounts`** table — no migration.
- **Frontend** — `OAuthButtons` fetches the enabled providers and renders brand buttons on **login** + **register**; the login page now surfaces `?error=` codes from the redirect.
- **`docs/SOCIAL_LOGIN.md`** — setup + how to add another provider.

## Safe to merge now
The buttons only render once the secrets exist, so this is **inert in production** until the OAuth apps are registered and secrets set:

```
wrangler secret put GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET
wrangler secret put DISCORD_CLIENT_ID / DISCORD_CLIENT_SECRET
```
Callback URLs: `https://hwmnbn.me/api/auth/oauth/{github,discord}/callback`

`tsc -b` and `react-router build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)